### PR TITLE
Add session-based authentication with login and logout

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthenticatedSessionController extends Controller
+{
+    /**
+     * Handle an incoming authentication request.
+     */
+    public function store(LoginRequest $request): RedirectResponse
+    {
+        $request->authenticate();
+
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('dashboard'));
+    }
+
+    /**
+     * Destroy an authenticated session.
+     */
+    public function destroy(Request $request): RedirectResponse
+    {
+        Auth::logout();
+
+        $request->session()->invalidate();
+
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login');
+    }
+}

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+            'remember' => ['boolean'],
+        ];
+    }
+
+    /**
+     * Attempt to authenticate the request's credentials.
+     *
+     * @throws ValidationException
+     */
+    public function authenticate(): void
+    {
+        $this->ensureIsNotRateLimited();
+
+        if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+            RateLimiter::hit($this->throttleKey());
+
+            throw ValidationException::withMessages([
+                'email' => __('auth.failed'),
+            ]);
+        }
+
+        RateLimiter::clear($this->throttleKey());
+    }
+
+    /**
+     * Ensure the login request is not rate limited.
+     *
+     * @throws ValidationException
+     */
+    protected function ensureIsNotRateLimited(): void
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+            return;
+        }
+
+        event(new Lockout($this));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'email' => trans('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    protected function throttleKey(): string
+    {
+        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+    }
+}

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -16,7 +16,7 @@ return [
     */
 
     'ssr' => [
-        'enabled' => true,
+        'enabled' => false,
         'url' => 'http://127.0.0.1:13714',
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,9 +2,16 @@
 
 namespace Database\Seeders;
 
+use App\Models\Branch;
+use App\Models\CommissionNote;
+use App\Models\Company;
+use App\Models\Employee;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 class DatabaseSeeder extends Seeder
 {
@@ -13,6 +20,63 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        // Create permissions
+        Permission::create(['name' => 'view commission notes']);
+        Permission::create(['name' => 'manage commission notes']);
+
+        // Create roles
+        $viewer = Role::create(['name' => 'viewer']);
+        $viewer->givePermissionTo('view commission notes');
+
+        $manager = Role::create(['name' => 'manager']);
+        $manager->givePermissionTo(['view commission notes', 'manage commission notes']);
+
+        // Create company
+        $company = Company::create(['name' => 'Spar']);
+
+        // Create two branches
+        $branchA = Branch::create(['company_id' => $company->id, 'name' => 'Spar Bellville']);
+        $branchB = Branch::create(['company_id' => $company->id, 'name' => 'Spar Gardens']);
+
+        // Create two employees in different branches
+        $emp1 = Employee::create(['company_id' => $company->id, 'branch_id' => $branchA->id, 'name' => 'Alice Nkosi']);
+        $emp2 = Employee::create(['company_id' => $company->id, 'branch_id' => $branchB->id, 'name' => 'Bob Dlamini']);
+
+        // Create users
+        $managerUser = User::create([
+            'name' => 'Admin Manager',
+            'email' => 'manager@example.com',
+            'password' => Hash::make('password'),
+        ]);
+        $managerUser->assignRole('manager');
+
+        $viewerUser = User::create([
+            'name' => 'View Only',
+            'email' => 'viewer@example.com',
+            'password' => Hash::make('password'),
+        ]);
+        $viewerUser->assignRole('viewer');
+
+        // Seed the two commission notes as per the exercise
+        CommissionNote::create([
+            'company_id' => $company->id,
+            'branch_id' => $branchA->id,
+            'employee_id' => $emp1->id,
+            'created_by' => $managerUser->id,
+            'amount' => 10000.00,
+            'description' => 'Commission payment - Alice',
+            'payment_date' => now()->toDateString(),
+        ]);
+
+        CommissionNote::create([
+            'company_id' => $company->id,
+            'branch_id' => $branchB->id,
+            'employee_id' => $emp2->id,
+            'created_by' => $managerUser->id,
+            'amount' => 20000.00,
+            'description' => 'Commission payment - Bob',
+            'payment_date' => now()->toDateString(),
+        ]);
         // User::factory(10)->create();
 
         User::factory()->create([

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
 
   db:
     image: mariadb:11
+    ports:
+      - "3306:3306"
     environment:
       MYSQL_DATABASE: earn_wise_db
       MYSQL_USER: earn_wise_user

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,18 @@
 <?php
 
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use Illuminate\Support\Facades\Route;
 
 Route::inertia('/', 'Welcome')->name('home');
 
-Route::inertia('/login', 'Auth/Login')->name('login');
+Route::middleware('guest')->group(function () {
+    Route::inertia('/login', 'Auth/Login')->name('login');
+    Route::post('/login', [AuthenticatedSessionController::class, 'store']);
+});
+
+Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+    ->name('logout')
+    ->middleware('auth');
 
 Route::inertia('/dashboard', 'Dashboard/Index')
     ->name('dashboard')


### PR DESCRIPTION
Closes #15

## Summary

- Add `AuthenticatedSessionController` handling `POST /login` (store) and `POST /logout` (destroy)
- Add `LoginRequest` with email/password validation, rate limiting (5 attempts), and lockout support
- Update `routes/web.php`: login routes wrapped in `guest` middleware; logout route requires `auth`
- Update `DatabaseSeeder` to seed roles (`viewer`, `manager`), permissions, company, branches, employees, and commission notes
- Disable Inertia SSR in config (development convenience)
- Expose MariaDB port 3306 in `docker-compose.yml`