### PR TITLE
Link employees to users via user_id relationship

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -3,8 +3,24 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Employee extends Model
 {
-    //
+    protected $fillable = ['company_id', 'branch_id', 'user_id', 'name'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -18,16 +19,26 @@ class User extends Authenticatable
     /** @use HasFactory<UserFactory> */
     use HasFactory, HasRoles, Notifiable;
 
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
     protected function casts(): array
     {
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function employees(): HasMany
+    {
+        return $this->hasMany(Employee::class);
+    }
+
+    public function companies()
+    {
+        return Company::whereIn('id', $this->employees()->select('company_id'));
+    }
+
+    public function branches()
+    {
+        return Branch::whereIn('id', $this->employees()->select('branch_id'));
     }
 }

--- a/database/migrations/2026_04_26_110139_add_user_id_to_employees_table.php
+++ b/database/migrations/2026_04_26_110139_add_user_id_to_employees_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->after('branch_id')->constrained()->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -38,10 +38,6 @@ class DatabaseSeeder extends Seeder
         $branchA = Branch::create(['company_id' => $company->id, 'name' => 'Spar Bellville']);
         $branchB = Branch::create(['company_id' => $company->id, 'name' => 'Spar Gardens']);
 
-        // Create two employees in different branches
-        $emp1 = Employee::create(['company_id' => $company->id, 'branch_id' => $branchA->id, 'name' => 'Alice Nkosi']);
-        $emp2 = Employee::create(['company_id' => $company->id, 'branch_id' => $branchB->id, 'name' => 'Bob Dlamini']);
-
         // Create users
         $managerUser = User::create([
             'name' => 'Admin Manager',
@@ -56,6 +52,13 @@ class DatabaseSeeder extends Seeder
             'password' => Hash::make('password'),
         ]);
         $viewerUser->assignRole('viewer');
+
+        // Create two employees in different branches, linked to manager (belongs to both branches)
+        $emp1 = Employee::create(['company_id' => $company->id, 'branch_id' => $branchA->id, 'user_id' => $managerUser->id, 'name' => 'Alice Nkosi']);
+        $emp2 = Employee::create(['company_id' => $company->id, 'branch_id' => $branchB->id, 'user_id' => $managerUser->id, 'name' => 'Bob Dlamini']);
+
+        // Viewer only linked to branchA
+        Employee::create(['company_id' => $company->id, 'branch_id' => $branchA->id, 'user_id' => $viewerUser->id, 'name' => 'View Only']);
 
         // Seed the two commission notes as per the exercise
         CommissionNote::create([

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -1,3 +1,11 @@
+export type Employee = {
+    id: number;
+    name: string;
+    company_id: number;
+    branch_id: number;
+    user_id: number | null;
+};
+
 export type User = {
     id: number;
     name: string;
@@ -6,6 +14,7 @@ export type User = {
     email_verified_at: string | null;
     created_at: string;
     updated_at: string;
+    employees?: Employee[];
     [key: string]: unknown;
 };
 


### PR DESCRIPTION
Closes #21

Add a nullable user_id foreign key to the employees table so each employee record can be linked to an authenticated user.

## Changes

- Migration: adds nullable user_id FK to employees with nullOnDelete cascade
- Employee model: adds fillable fields and belongsTo relationships for User, Company, and Branch
- User model: adds hasMany employees relationship plus companies() and branches() query helpers derived from employee records
- DatabaseSeeder: employees are now created after users and linked via user_id
- TypeScript: adds Employee type to auth.ts and an optional employees array on the User type

## Notes

Two pre-existing test failures exist on the develop branch (ViteException for missing Vite manifest entries); these are not introduced by this PR.