### PR TITLE
Add company switcher to app layout

### DIFF
--- a/app/Http/Controllers/CompanySwitchController.php
+++ b/app/Http/Controllers/CompanySwitchController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class CompanySwitchController extends Controller
+{
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'company_id' => ['required', 'integer'],
+        ]);
+
+        $companyId = (int) $request->input('company_id');
+
+        abort_unless(
+            $request->user()->companies()->whereKey($companyId)->exists(),
+            403,
+            'You do not belong to this company.'
+        );
+
+        session(['selected_company_id' => $companyId]);
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -35,11 +35,15 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        $user = $request->user();
+
         return [
             ...parent::share($request),
             'name' => config('app.name'),
             'auth' => [
-                'user' => $request->user(),
+                'user' => $user,
+                'companies' => $user ? $user->companies()->get(['id', 'name']) : [],
+                'selectedCompanyId' => session('selected_company_id'),
             ],
         ];
     }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -55,6 +55,30 @@
     --color-slate-800: oklch(0.283 0.015 256.79);
     --color-slate-900: oklch(0.207 0.01 248.31);
     --color-slate-950: oklch(0.163 0.009 264.29);
+
+    --color-black-50: #f6f6f6;
+    --color-black-100: #e7e7e7;
+    --color-black-200: #d1d1d1;
+    --color-black-300: #b0b0b0;
+    --color-black-400: #888888;
+    --color-black-500: #6d6d6d;
+    --color-black-600: #5d5d5d;
+    --color-black-700: #4f4f4f;
+    --color-black-800: #454545;
+    --color-black-900: #3d3d3d;
+    --color-black-950: #121212;
+
+    --color-white-50: #ffffff;
+    --color-white-100: #efefef;
+    --color-white-200: #dcdcdc;
+    --color-white-300: #bdbdbd;
+    --color-white-400: #989898;
+    --color-white-500: #7c7c7c;
+    --color-white-600: #656565;
+    --color-white-700: #525252;
+    --color-white-800: #464646;
+    --color-white-900: #3d3d3d;
+    --color-white-950: #292929;
 }
 
 @utility shadow-smooth {

--- a/resources/js/components/CompanySwitcher.vue
+++ b/resources/js/components/CompanySwitcher.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import type { DropdownMenuItem } from '@nuxt/ui';
+import { computed } from 'vue';
+import { useCompanyStore } from '@/stores/company';
+
+defineProps<{
+    collapsed?: boolean;
+}>();
+
+const companyStore = useCompanyStore();
+
+const buttonLabel = computed(() => {
+    const company = companyStore.selectedCompany;
+
+    if (company) {
+        return company.name;
+    }
+
+    if (companyStore.companies.length === 0) {
+        return 'No companies';
+    }
+
+    return 'Select company';
+});
+
+const items = computed<DropdownMenuItem[][]>(() => {
+    const groups: DropdownMenuItem[][] = [];
+
+    if (companyStore.companies.length > 0) {
+        groups.push(
+            companyStore.companies.map((c) => ({
+                label: c.name,
+                type: 'checkbox' as const,
+                checked: companyStore.selectedCompanyId === c.id,
+                onSelect: () => companyStore.switchCompany(c.id),
+            })),
+        );
+    }
+
+    return groups;
+});
+</script>
+
+<template>
+    <UDropdownMenu
+        :items="items"
+        :disabled="companyStore.companies.length === 0"
+        :content="{ align: 'center', collisionPadding: 12 }"
+        :ui="{
+            content: collapsed
+                ? 'w-48'
+                : 'w-(--reka-dropdown-menu-trigger-width)',
+        }"
+    >
+        <UButton
+            v-bind="{
+                label: collapsed ? undefined : buttonLabel,
+                icon: 'i-lucide-building-2',
+                trailingIcon: collapsed
+                    ? undefined
+                    : 'i-lucide-chevrons-up-down',
+            }"
+            color="neutral"
+            variant="ghost"
+            block
+            :square="collapsed"
+            :disabled="companyStore.companies.length === 0"
+            :class="[!collapsed && 'py-2']"
+            :ui="{
+                base: 'hover:bg-white/15 data-[state=open]:bg-white/15 text-white',
+            }"
+        />
+    </UDropdownMenu>
+</template>

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -2,6 +2,7 @@
 import { Link, usePage } from '@inertiajs/vue3';
 import { computed, ref, shallowRef } from 'vue';
 import AppLogo from '@/components/AppLogo.vue';
+import CompanySwitcher from '@/components/CompanySwitcher.vue';
 import type { User } from '@/types/auth';
 
 const page = usePage();
@@ -37,10 +38,12 @@ const panelUi = shallowRef({});
             >
                 <template #header>
                     <Link href="/dashboard" class="flex items-center px-1">
-                        <AppLogo class="h-7 w-auto" />
+                        <AppLogo class="h-auto w-full" />
                     </Link>
                 </template>
-
+                <USeparator :ui="{ border: 'border-white-100/80' }" />
+                <CompanySwitcher :collapsed="isCollapsed" />
+                <USeparator :ui="{ border: 'border-white-100/80' }" />
                 <UNavigationMenu
                     :items="
                         navLinks.map((link) => ({

--- a/resources/js/pages/Dashboard/Index.vue
+++ b/resources/js/pages/Dashboard/Index.vue
@@ -42,10 +42,10 @@ const stats = [
 
     <div class="flex flex-col gap-6">
         <div>
-            <h1 class="text-2xl font-bold text-(--ui-text-highlighted)">
+            <h1 class="text-2xl font-bold text-highlighted">
                 Welcome back{{ user?.name ? `, ${user.name}` : '' }}
             </h1>
-            <p class="mt-1 text-sm text-(--ui-text-muted)">
+            <p class="mt-1 text-sm text-muted">
                 Here's an overview of your finances.
             </p>
         </div>
@@ -54,7 +54,7 @@ const stats = [
             <UCard v-for="stat in stats" :key="stat.label">
                 <div class="flex items-start justify-between">
                     <div>
-                        <p class="text-sm text-(--ui-text-muted)">
+                        <p class="text-sm text-muted">
                             {{ stat.label }}
                         </p>
                         <p

--- a/resources/js/stores/company.ts
+++ b/resources/js/stores/company.ts
@@ -1,0 +1,30 @@
+import { usePage, router } from '@inertiajs/vue3';
+import { defineStore } from 'pinia';
+import { computed } from 'vue';
+import type { Company } from '@/types/auth';
+
+export const useCompanyStore = defineStore('company', () => {
+    const page = usePage();
+
+    const companies = computed<Company[]>(
+        () => page.props.auth?.companies ?? [],
+    );
+
+    const selectedCompanyId = computed<number | null>(
+        () => page.props.auth?.selectedCompanyId ?? null,
+    );
+
+    const selectedCompany = computed<Company | undefined>(() =>
+        companies.value.find((c) => c.id === selectedCompanyId.value),
+    );
+
+    function switchCompany(id: number): void {
+        router.post(
+            '/company/switch',
+            { company_id: id },
+            { preserveScroll: true },
+        );
+    }
+
+    return { companies, selectedCompanyId, selectedCompany, switchCompany };
+});

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -1,3 +1,8 @@
+export type Company = {
+    id: number;
+    name: string;
+};
+
 export type Employee = {
     id: number;
     name: string;
@@ -20,4 +25,6 @@ export type User = {
 
 export type Auth = {
     user: User;
+    companies: Company[];
+    selectedCompanyId: number | null;
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\CompanySwitchController;
 use Illuminate\Support\Facades\Route;
 
 Route::inertia('/', 'Welcome')->name('home');
@@ -16,4 +17,8 @@ Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
 
 Route::inertia('/dashboard', 'Dashboard/Index')
     ->name('dashboard')
+    ->middleware('auth');
+
+Route::post('/company/switch', [CompanySwitchController::class, 'store'])
+    ->name('company.switch')
     ->middleware('auth');


### PR DESCRIPTION
Closes #25

Adds a company switcher that allows users to switch between their associated companies directly from the app sidebar. The active company is persisted in the session and shared to all Inertia page props so components can react to it.

### Changes
- **CompanySwitchController** — validates the requested company belongs to the authenticated user, then writes selected_company_id to the session
- **Route** — registers POST /company/switch pointing at the new controller
- **HandleInertiaRequests** — shares companies list and selectedCompanyId to all pages via Inertia props
- **auth.ts types** — adds Company interface and extends the shared Auth type with companies and selectedCompanyId
- **company store** — Pinia store wrapping the shared Inertia data with a switchCompany action that POSTs to the backend
- **CompanySwitcher.vue** — dropdown component using UDropdownMenu/UButton; supports a collapsed (icon-only) mode for narrow sidebars
- **AppLayout** — renders <CompanySwitcher> in the sidebar above the nav links
- **app.css / Dashboard** — minor styling and layout tweaks