### PR TITLE
Add user management page for admin managers

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class UserController extends Controller
+{
+    public function index(Request $request): Response|RedirectResponse
+    {
+        $companyId = session('selected_company_id');
+
+        if (! $companyId) {
+            return redirect()->route('dashboard');
+        }
+
+        $branches = Branch::where('company_id', $companyId)
+            ->orderBy('name')
+            ->get(['id', 'name', 'company_id']);
+
+        $users = User::whereIn(
+            'id',
+            Employee::where('company_id', $companyId)->select('user_id')
+        )
+            ->with(['employees' => fn ($q) => $q->where('company_id', $companyId)->with('branch:id,name')])
+            ->orderBy('name')
+            ->get()
+            ->map(fn (User $user) => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'roles' => $user->getRoleNames(),
+                'branches' => $user->employees->map(fn ($e) => [
+                    'id' => $e->branch?->id,
+                    'name' => $e->branch?->name,
+                ]),
+            ]);
+
+        return Inertia::render('Users/Index', [
+            'users' => $users,
+            'branches' => $branches,
+            'availableRoles' => ['viewer', 'manager'],
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $companyId = session('selected_company_id');
+
+        if (! $companyId) {
+            return redirect()->route('dashboard');
+        }
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+            'branch_id' => ['required', 'integer', 'exists:branches,id'],
+            'role' => ['required', 'string', 'in:viewer,manager'],
+        ]);
+
+        $branch = Branch::where('id', $validated['branch_id'])
+            ->where('company_id', $companyId)
+            ->firstOrFail();
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
+        ]);
+
+        $user->assignRole($validated['role']);
+
+        Employee::create([
+            'company_id' => $companyId,
+            'branch_id' => $branch->id,
+            'user_id' => $user->id,
+            'name' => $validated['name'],
+        ]);
+
+        return redirect()->route('users.index');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -44,6 +44,7 @@ class HandleInertiaRequests extends Middleware
                 'user' => $user,
                 'companies' => $user ? $user->companies()->get(['id', 'name']) : [],
                 'selectedCompanyId' => session('selected_company_id'),
+                'roles' => $user ? $user->getRoleNames() : [],
             ],
         ];
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Spatie\Permission\Middleware\RoleMiddleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -16,6 +17,9 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
+        ]);
+        $middleware->alias([
+            'role' => RoleMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -7,14 +7,26 @@ import type { User } from '@/types/auth';
 
 const page = usePage();
 const user = computed(() => page.props.auth?.user as User | undefined);
+const isManager = computed(() =>
+    (((page.props.auth as any)?.roles as string[]) ?? []).includes('manager'),
+);
 
-const navLinks = [
+const navLinks = computed(() => [
     {
         label: 'Dashboard',
         icon: 'i-lucide-layout-dashboard',
         href: '/dashboard',
     },
-];
+    ...(isManager.value
+        ? [
+              {
+                  label: 'Users',
+                  icon: 'i-lucide-users',
+                  href: '/users',
+              },
+          ]
+        : []),
+]);
 const open = ref(false);
 const isCollapsed = ref(false);
 const panelUi = shallowRef({});

--- a/resources/js/pages/Users/Index.vue
+++ b/resources/js/pages/Users/Index.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3';
+import { computed, h, ref, resolveComponent } from 'vue';
+import AppLayout from '@/layouts/AppLayout.vue';
+import type { Branch } from '@/types/auth';
+
+defineOptions({ layout: AppLayout });
+
+type UserRow = {
+    id: number;
+    name: string;
+    email: string;
+    roles: string[];
+    branches: { id: number | null; name: string | null }[];
+};
+
+const props = defineProps<{
+    users: UserRow[];
+    branches: Branch[];
+    availableRoles: string[];
+}>();
+
+const isOpen = ref(false);
+
+const form = useForm({
+    name: '',
+    email: '',
+    password: '',
+    password_confirmation: '',
+    branch_id: undefined as number | undefined,
+    role: '',
+});
+
+function submit() {
+    form.post('/users', {
+        onSuccess: () => {
+            isOpen.value = false;
+            form.reset();
+        },
+    });
+}
+
+const UBadge = resolveComponent('UBadge');
+
+const columns = [
+    {
+        accessorKey: 'name',
+        header: 'Name',
+    },
+    {
+        accessorKey: 'email',
+        header: 'Email',
+    },
+    {
+        accessorKey: 'roles',
+        header: 'Role',
+        cell: ({ row }: any) =>
+            h(
+                'div',
+                { class: 'flex gap-1 flex-wrap' },
+                row.original.roles.length
+                    ? row.original.roles.map((role: string) =>
+                          h(UBadge, {
+                              label:
+                                  role.charAt(0).toUpperCase() + role.slice(1),
+                              color: role === 'manager' ? 'primary' : 'neutral',
+                              variant: 'subtle',
+                              size: 'sm',
+                          }),
+                      )
+                    : [
+                          h(
+                              'span',
+                              { class: 'text-sm text-(--ui-text-dimmed)' },
+                              '—',
+                          ),
+                      ],
+            ),
+    },
+    {
+        accessorKey: 'branches',
+        header: 'Branch',
+        cell: ({ row }: any) =>
+            h(
+                'div',
+                { class: 'flex flex-wrap gap-1' },
+                row.original.branches.length
+                    ? row.original.branches.map((b: { name: string | null }) =>
+                          h('span', { class: 'text-sm' }, b.name ?? '—'),
+                      )
+                    : [
+                          h(
+                              'span',
+                              { class: 'text-sm text-(--ui-text-dimmed)' },
+                              '—',
+                          ),
+                      ],
+            ),
+    },
+];
+
+const branchItems = computed(() =>
+    props.branches.map((b) => ({ label: b.name, value: b.id })),
+);
+
+const roleItems = computed(() =>
+    props.availableRoles.map((r) => ({
+        label: r.charAt(0).toUpperCase() + r.slice(1),
+        value: r,
+    })),
+);
+</script>
+
+<template>
+    <Head title="Users" />
+
+    <div class="flex flex-col gap-6">
+        <div class="flex items-start justify-between">
+            <div>
+                <h1 class="text-2xl font-bold text-highlighted">Users</h1>
+                <p class="mt-1 text-sm text-muted">
+                    Manage users for this company.
+                </p>
+            </div>
+
+            <UModal
+                v-model:open="isOpen"
+                title="Create User"
+                description="Add a new user and assign them to a branch."
+            >
+                <UButton label="Create User" icon="i-lucide-user-plus" />
+
+                <template #body>
+                    <form class="flex flex-col gap-4" @submit.prevent="submit">
+                        <UFormField
+                            label="Name"
+                            required
+                            :error="form.errors.name"
+                        >
+                            <UInput
+                                v-model="form.name"
+                                placeholder="Full name"
+                                class="w-full"
+                                autofocus
+                            />
+                        </UFormField>
+
+                        <UFormField
+                            label="Email"
+                            required
+                            :error="form.errors.email"
+                        >
+                            <UInput
+                                v-model="form.email"
+                                type="email"
+                                placeholder="email@example.com"
+                                class="w-full"
+                            />
+                        </UFormField>
+
+                        <UFormField
+                            label="Password"
+                            required
+                            :error="form.errors.password"
+                        >
+                            <UInput
+                                v-model="form.password"
+                                type="password"
+                                placeholder="••••••••"
+                                class="w-full"
+                            />
+                        </UFormField>
+
+                        <UFormField
+                            label="Confirm Password"
+                            required
+                            :error="form.errors.password_confirmation"
+                        >
+                            <UInput
+                                v-model="form.password_confirmation"
+                                type="password"
+                                placeholder="••••••••"
+                                class="w-full"
+                            />
+                        </UFormField>
+
+                        <UFormField
+                            label="Branch"
+                            required
+                            :error="form.errors.branch_id"
+                        >
+                            <USelect
+                                v-model="form.branch_id"
+                                :items="branchItems"
+                                placeholder="Select a branch"
+                                class="w-full"
+                            />
+                        </UFormField>
+
+                        <UFormField
+                            label="Role"
+                            required
+                            :error="form.errors.role"
+                        >
+                            <USelect
+                                v-model="form.role"
+                                :items="roleItems"
+                                placeholder="Select a role"
+                                class="w-full"
+                            />
+                        </UFormField>
+                    </form>
+                </template>
+
+                <template #footer>
+                    <div class="flex justify-end gap-2">
+                        <UButton
+                            label="Cancel"
+                            color="neutral"
+                            variant="ghost"
+                            @click="isOpen = false"
+                        />
+                        <UButton
+                            label="Create User"
+                            icon="i-lucide-user-plus"
+                            :loading="form.processing"
+                            @click="submit"
+                        />
+                    </div>
+                </template>
+            </UModal>
+        </div>
+
+        <UCard>
+            <UTable
+                :data="users"
+                :columns="columns"
+                empty="No users found for this company."
+            />
+        </UCard>
+    </div>
+</template>

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -3,6 +3,12 @@ export type Company = {
     name: string;
 };
 
+export type Branch = {
+    id: number;
+    name: string;
+    company_id: number;
+};
+
 export type Employee = {
     id: number;
     name: string;
@@ -27,4 +33,5 @@ export type Auth = {
     user: User;
     companies: Company[];
     selectedCompanyId: number | null;
+    roles: string[];
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\CompanySwitchController;
+use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 Route::inertia('/', 'Welcome')->name('home');
@@ -22,3 +23,8 @@ Route::inertia('/dashboard', 'Dashboard/Index')
 Route::post('/company/switch', [CompanySwitchController::class, 'store'])
     ->name('company.switch')
     ->middleware('auth');
+
+Route::middleware(['auth', 'role:manager'])->group(function () {
+    Route::get('/users', [UserController::class, 'index'])->name('users.index');
+    Route::post('/users', [UserController::class, 'store'])->name('users.store');
+});


### PR DESCRIPTION
Closes #27

## Summary
- New \/users\ page accessible only to users with the \manager\ role, scoped to the currently selected company
- \UserController\ with \index()\ (list users + branches) and \store()\ (create user + employee record + assign role)
- Frontend: \Users/Index.vue\ with a \UTable\ listing and a \UModal\ form (name, email, password, branch, role)
- Conditional Users nav link in the sidebar — only visible to managers
- Shared \uth.roles\ prop via \HandleInertiaRequests\ + updated TypeScript types

## Test plan
- [ ] Log in as \manager@example.com\ — Users link appears in sidebar
- [ ] Log in as \iewer@example.com\ — Users link is hidden; visiting \/users\ returns 403
- [ ] Visit \/users\ as manager without a selected company — redirects to dashboard
- [ ] Create a new user, select a branch and role — user appears in the table
- [ ] Validation errors display correctly inline (duplicate email, missing fields, weak password)