### PR TITLE
Add commission notes CRUD with branch-scoped navigation

### DIFF
--- a/app/Http/Controllers/CommissionNoteController.php
+++ b/app/Http/Controllers/CommissionNoteController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCommissionNoteRequest;
+use App\Http\Requests\UpdateCommissionNoteRequest;
+use App\Models\Branch;
+use App\Models\CommissionNote;
+use App\Models\Company;
+use App\Models\User;
+use App\Services\CommissionNoteService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class CommissionNoteController extends Controller
+{
+    public function __construct(private CommissionNoteService $service) {}
+
+    public function index(Company $company, Branch $branch): Response
+    {
+        $this->authorize('view commission notes');
+
+        /** @var User $user */
+        $user = Auth::user();
+
+        return Inertia::render('CommissionNotes/Index', [
+            'company' => $company,
+            'branch' => $branch,
+            'notes' => $this->service->list($company->id, $branch->id),
+            'employees' => $branch->employees,
+            'canManage' => $user->can('manage commission notes'),
+        ]);
+    }
+
+    public function store(StoreCommissionNoteRequest $request): RedirectResponse
+    {
+        $this->service->create($request->validated());
+
+        return back()->with('success', 'Commission note created.');
+    }
+
+    public function update(UpdateCommissionNoteRequest $request, CommissionNote $note): RedirectResponse
+    {
+        $this->service->update($note, $request->validated());
+
+        return back()->with('success', 'Commission note updated.');
+    }
+
+    public function destroy(CommissionNote $note): RedirectResponse
+    {
+        $this->authorize('manage commission notes');
+
+        $this->service->delete($note);
+
+        return back()->with('success', 'Commission note deleted.');
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Branch;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -36,6 +37,7 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request): array
     {
         $user = $request->user();
+        $selectedCompanyId = session('selected_company_id');
 
         return [
             ...parent::share($request),
@@ -43,7 +45,10 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $user,
                 'companies' => $user ? $user->companies()->get(['id', 'name']) : [],
-                'selectedCompanyId' => session('selected_company_id'),
+                'selectedCompanyId' => $selectedCompanyId,
+                'branches' => $user && $selectedCompanyId
+                    ? Branch::where('company_id', $selectedCompanyId)->get(['id', 'name'])
+                    : [],
                 'roles' => $user ? $user->getRoleNames() : [],
             ],
         ];

--- a/app/Http/Requests/StoreCommissionNoteRequest.php
+++ b/app/Http/Requests/StoreCommissionNoteRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCommissionNoteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('manage commission notes');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'company_id' => ['required', 'integer', 'exists:companies,id'],
+            'branch_id' => ['required', 'integer', 'exists:branches,id'],
+            'employee_id' => ['required', 'integer', 'exists:employees,id'],
+            'amount' => ['required', 'numeric', 'min:0'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'payment_date' => ['required', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCommissionNoteRequest.php
+++ b/app/Http/Requests/UpdateCommissionNoteRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCommissionNoteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('manage commission notes')
+            || $this->route('note')->created_by === $this->user()->id;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'amount' => ['required', 'numeric', 'min:0'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'payment_date' => ['required', 'date'],
+        ];
+    }
+}

--- a/app/Services/CommissionNoteService.php
+++ b/app/Services/CommissionNoteService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\CommissionNote;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+
+class CommissionNoteService
+{
+    public function list(int $companyId, int $branchId): Collection
+    {
+        return CommissionNote::with(['employee', 'author'])
+            ->where('company_id', $companyId)
+            ->where('branch_id', $branchId)
+            ->latest()
+            ->get();
+    }
+
+    public function create(array $validated): CommissionNote
+    {
+        return CommissionNote::create([
+            'company_id' => $validated['company_id'],
+            'branch_id' => $validated['branch_id'],
+            'employee_id' => $validated['employee_id'],
+            'created_by' => Auth::id(),
+            'amount' => $validated['amount'],
+            'description' => $validated['description'] ?? null,
+            'payment_date' => $validated['payment_date'],
+        ]);
+    }
+
+    public function update(CommissionNote $note, array $validated): CommissionNote
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        if ($note->created_by !== $user->id && ! $user->can('manage commission notes')) {
+            throw new AuthorizationException('You are not authorised to edit this note.');
+        }
+
+        $note->update([
+            'amount' => $validated['amount'],
+            'description' => $validated['description'] ?? $note->description,
+            'payment_date' => $validated['payment_date'],
+        ]);
+
+        return $note->fresh();
+    }
+
+    public function delete(CommissionNote $note): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        if ($note->created_by !== $user->id && ! $user->can('manage commission notes')) {
+            throw new AuthorizationException('You are not authorised to delete this note.');
+        }
+
+        $note->delete();
+    }
+}

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -3,19 +3,21 @@ import { Link, usePage } from '@inertiajs/vue3';
 import { computed, ref, shallowRef } from 'vue';
 import AppLogo from '@/components/AppLogo.vue';
 import CompanySwitcher from '@/components/CompanySwitcher.vue';
-import type { User } from '@/types/auth';
+import type { Auth, Branch, User } from '@/types/auth';
 
 const page = usePage();
-const user = computed(() => page.props.auth?.user as User | undefined);
-const isManager = computed(() =>
-    (((page.props.auth as any)?.roles as string[]) ?? []).includes('manager'),
-);
+const auth = computed(() => page.props.auth as Auth | undefined);
+const user = computed(() => auth.value?.user as User | undefined);
+const isManager = computed(() => (auth.value?.roles ?? []).includes('manager'));
+const selectedCompanyId = computed(() => auth.value?.selectedCompanyId ?? null);
+const branches = computed<Branch[]>(() => auth.value?.branches ?? []);
 
 const navLinks = computed(() => [
     {
         label: 'Dashboard',
         icon: 'i-lucide-layout-dashboard',
         href: '/dashboard',
+        children: undefined as undefined | { label: string; href: string }[],
     },
     ...(isManager.value
         ? [
@@ -23,6 +25,28 @@ const navLinks = computed(() => [
                   label: 'Users',
                   icon: 'i-lucide-users',
                   href: '/users',
+                  children: undefined as
+                      | undefined
+                      | { label: string; href: string }[],
+              },
+          ]
+        : []),
+    ...(selectedCompanyId.value && branches.value.length
+        ? [
+              {
+                  label: 'Commission Notes',
+                  icon: 'i-lucide-file-text',
+                  href:
+                      branches.value.length === 1
+                          ? `/companies/${selectedCompanyId.value}/branches/${branches.value[0]!.id}/notes`
+                          : undefined,
+                  children:
+                      branches.value.length > 1
+                          ? branches.value.map((b) => ({
+                                label: b.name,
+                                href: `/companies/${selectedCompanyId.value}/branches/${b.id}/notes`,
+                            }))
+                          : undefined,
               },
           ]
         : []),
@@ -57,12 +81,24 @@ const panelUi = shallowRef({});
                 <CompanySwitcher :collapsed="isCollapsed" />
                 <USeparator :ui="{ border: 'border-white-100/80' }" />
                 <UNavigationMenu
+                    :ui="{
+                        link: 'before:bg-transparent data-[active]:text-primary-500 text-white-50',
+                        linkLeadingIcon:
+                            'group-data-[active]:text-primary-500 text-white-50',
+                    }"
                     :items="
                         navLinks.map((link) => ({
                             label: link.label,
                             icon: link.icon,
-                            to: link.href,
-                            as: 'a',
+                            ...(link.children
+                                ? {
+                                      children: link.children.map((child) => ({
+                                          label: child.label,
+                                          to: child.href,
+                                          as: 'a',
+                                      })),
+                                  }
+                                : { to: link.href, as: 'a' }),
                         }))
                     "
                     orientation="vertical"

--- a/resources/js/pages/CommissionNotes/Index.vue
+++ b/resources/js/pages/CommissionNotes/Index.vue
@@ -1,0 +1,393 @@
+<script setup lang="ts">
+import { Head, router, useForm, usePage } from '@inertiajs/vue3';
+import { computed, h, resolveComponent, watch } from 'vue';
+import {
+    destroy as destroyAction,
+    store as storeAction,
+    update as updateAction,
+} from '@/actions/App/Http/Controllers/CommissionNoteController';
+import AppLayout from '@/layouts/AppLayout.vue';
+import { useNoteStore } from '@/stores/noteStore';
+import type { Branch, CommissionNote, Company, Employee } from '@/types/auth';
+
+defineOptions({ layout: AppLayout });
+
+const props = defineProps<{
+    company: Company;
+    branch: Branch;
+    notes: CommissionNote[];
+    employees: Employee[];
+    canManage: boolean;
+}>();
+
+const page = usePage();
+const noteStore = useNoteStore();
+
+const currentUserId = computed(
+    () => (page.props.auth as any)?.user?.id as number,
+);
+
+const filteredNotes = computed(() =>
+    noteStore.filterEmployeeId
+        ? props.notes.filter(
+              (n) => n.employee_id === noteStore.filterEmployeeId,
+          )
+        : props.notes,
+);
+
+const employeeItems = computed(() => [
+    { label: 'All Employees', value: null },
+    ...props.employees.map((e) => ({ label: e.name, value: e.id })),
+]);
+
+// ── Create form ──────────────────────────────────────────────────────────────
+
+const createForm = useForm({
+    company_id: props.company.id,
+    branch_id: props.branch.id,
+    employee_id: undefined as number | undefined,
+    amount: '',
+    description: '',
+    payment_date: '',
+});
+
+function submitCreate() {
+    createForm.post(
+        storeAction.url({ company: props.company.id, branch: props.branch.id }),
+        {
+            onSuccess: () => {
+                createForm.reset();
+                noteStore.closePanel();
+            },
+        },
+    );
+}
+
+// ── Edit form ─────────────────────────────────────────────────────────────────
+
+const editForm = useForm({
+    amount: '',
+    description: '',
+    payment_date: '',
+});
+
+watch(
+    () => noteStore.selectedNote,
+    (note) => {
+        if (note) {
+            editForm.amount = note.amount;
+            editForm.description = note.description ?? '';
+            editForm.payment_date = note.payment_date;
+        }
+    },
+);
+
+function submitEdit() {
+    if (!noteStore.selectedNote) {
+        return;
+    }
+
+    editForm.patch(updateAction.url(noteStore.selectedNote.id), {
+        onSuccess: () => noteStore.closePanel(),
+    });
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+function deleteNote(note: CommissionNote) {
+    if (
+        !confirm(
+            `Delete this commission note for ${note.employee?.name ?? 'this employee'}?`,
+        )
+    ) {
+        return;
+    }
+
+    router.delete(destroyAction.url(note.id), { preserveScroll: true });
+}
+
+// ── Table columns ─────────────────────────────────────────────────────────────
+
+const UBadge = resolveComponent('UBadge');
+
+const columns = [
+    {
+        accessorKey: 'employee',
+        header: 'Employee',
+        cell: ({ row }: any) =>
+            h(
+                'span',
+                { class: 'font-medium' },
+                row.original.employee?.name ?? '—',
+            ),
+    },
+    {
+        accessorKey: 'amount',
+        header: 'Amount',
+        cell: ({ row }: any) =>
+            h(
+                UBadge,
+                { color: 'success', variant: 'subtle', size: 'sm' },
+                {
+                    default: () =>
+                        `R ${Number(row.original.amount).toLocaleString('en-ZA', { minimumFractionDigits: 2 })}`,
+                },
+            ),
+    },
+    {
+        accessorKey: 'payment_date',
+        header: 'Payment Date',
+        cell: ({ row }: any) => h('span', {}, row.original.payment_date),
+    },
+    {
+        accessorKey: 'description',
+        header: 'Description',
+        cell: ({ row }: any) =>
+            h(
+                'span',
+                { class: 'text-(--ui-text-muted)' },
+                row.original.description ?? '—',
+            ),
+    },
+    {
+        accessorKey: 'author',
+        header: 'Created By',
+        cell: ({ row }: any) =>
+            h('span', { class: 'text-sm' }, row.original.author?.name ?? '—'),
+    },
+    {
+        id: 'actions',
+        header: '',
+    },
+];
+</script>
+
+<template>
+    <Head :title="`${company.name} — Commission Notes`" />
+
+    <div class="flex flex-col gap-6">
+        <div class="flex items-start justify-between">
+            <div>
+                <h1 class="text-2xl font-bold text-highlighted">
+                    {{ company.name }} &mdash; {{ branch.name }}
+                </h1>
+                <p class="mt-1 text-sm text-muted">Commission Notes</p>
+            </div>
+
+            <UButton
+                v-if="canManage"
+                label="Add Note"
+                icon="i-lucide-plus"
+                @click="noteStore.openCreate()"
+            />
+        </div>
+
+        <!-- Employee filter -->
+        <div class="flex items-center gap-3">
+            <USelect
+                :items="employeeItems"
+                :model-value="noteStore.filterEmployeeId"
+                placeholder="Filter by employee"
+                class="w-56"
+                @update:model-value="noteStore.setFilter($event)"
+            />
+        </div>
+
+        <!-- Notes table -->
+        <UCard>
+            <UTable
+                :data="filteredNotes"
+                :columns="columns"
+                empty="No commission notes found."
+            >
+                <template #actions-data="{ row }">
+                    <div class="flex items-center gap-2">
+                        <UButton
+                            v-if="
+                                canManage ||
+                                row.original.created_by === currentUserId
+                            "
+                            label="Edit"
+                            color="neutral"
+                            variant="ghost"
+                            size="xs"
+                            icon="i-lucide-pencil"
+                            @click="noteStore.selectNote(row.original)"
+                        />
+                        <UButton
+                            v-if="
+                                canManage ||
+                                row.original.created_by === currentUserId
+                            "
+                            label="Delete"
+                            color="error"
+                            variant="ghost"
+                            size="xs"
+                            icon="i-lucide-trash-2"
+                            @click="deleteNote(row.original)"
+                        />
+                    </div>
+                </template>
+            </UTable>
+        </UCard>
+    </div>
+
+    <!-- Create / Edit Slideover -->
+    <USlideover
+        v-model:open="noteStore.isPanelOpen"
+        :title="
+            noteStore.selectedNote
+                ? 'Edit Commission Note'
+                : 'New Commission Note'
+        "
+        :description="
+            noteStore.selectedNote
+                ? 'Update the details for this commission note.'
+                : 'Fill in the details to create a new commission note.'
+        "
+        @close="noteStore.closePanel()"
+    >
+        <template #body>
+            <!-- Create form -->
+            <form
+                v-if="!noteStore.selectedNote"
+                class="flex flex-col gap-4"
+                @submit.prevent="submitCreate"
+            >
+                <UFormField
+                    label="Employee"
+                    required
+                    :error="createForm.errors.employee_id"
+                >
+                    <USelect
+                        v-model="createForm.employee_id"
+                        :items="
+                            employees.map((e) => ({
+                                label: e.name,
+                                value: e.id,
+                            }))
+                        "
+                        placeholder="Select an employee"
+                        class="w-full"
+                    />
+                </UFormField>
+
+                <UFormField
+                    label="Amount (R)"
+                    required
+                    :error="createForm.errors.amount"
+                >
+                    <UInput
+                        v-model="createForm.amount"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        placeholder="0.00"
+                        class="w-full"
+                    />
+                </UFormField>
+
+                <UFormField
+                    label="Payment Date"
+                    required
+                    :error="createForm.errors.payment_date"
+                >
+                    <UInput
+                        v-model="createForm.payment_date"
+                        type="date"
+                        class="w-full"
+                    />
+                </UFormField>
+
+                <UFormField
+                    label="Description"
+                    :error="createForm.errors.description"
+                >
+                    <UTextarea
+                        v-model="createForm.description"
+                        placeholder="Optional description…"
+                        :rows="3"
+                        class="w-full"
+                    />
+                </UFormField>
+            </form>
+
+            <!-- Edit form -->
+            <form
+                v-else
+                class="flex flex-col gap-4"
+                @submit.prevent="submitEdit"
+            >
+                <UFormField
+                    label="Amount (R)"
+                    required
+                    :error="editForm.errors.amount"
+                >
+                    <UInput
+                        v-model="editForm.amount"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        placeholder="0.00"
+                        class="w-full"
+                    />
+                </UFormField>
+
+                <UFormField
+                    label="Payment Date"
+                    required
+                    :error="editForm.errors.payment_date"
+                >
+                    <UInput
+                        v-model="editForm.payment_date"
+                        type="date"
+                        class="w-full"
+                    />
+                </UFormField>
+
+                <UFormField
+                    label="Description"
+                    :error="editForm.errors.description"
+                >
+                    <UTextarea
+                        v-model="editForm.description"
+                        placeholder="Optional description…"
+                        :rows="3"
+                        class="w-full"
+                    />
+                </UFormField>
+            </form>
+        </template>
+
+        <template #footer>
+            <div v-if="!noteStore.selectedNote" class="flex justify-end gap-2">
+                <UButton
+                    label="Cancel"
+                    color="neutral"
+                    variant="ghost"
+                    @click="noteStore.closePanel()"
+                />
+                <UButton
+                    label="Save Note"
+                    icon="i-lucide-save"
+                    :loading="createForm.processing"
+                    @click="submitCreate"
+                />
+            </div>
+            <div v-else class="flex justify-end gap-2">
+                <UButton
+                    label="Cancel"
+                    color="neutral"
+                    variant="ghost"
+                    @click="noteStore.closePanel()"
+                />
+                <UButton
+                    label="Update Note"
+                    icon="i-lucide-save"
+                    :loading="editForm.processing"
+                    @click="submitEdit"
+                />
+            </div>
+        </template>
+    </USlideover>
+</template>

--- a/resources/js/stores/noteStore.ts
+++ b/resources/js/stores/noteStore.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import type { CommissionNote } from '@/types/auth';
+
+export const useNoteStore = defineStore('notes', () => {
+    const selectedNote = ref<CommissionNote | null>(null);
+    const isPanelOpen = ref(false);
+    const filterEmployeeId = ref<number | null>(null);
+
+    function selectNote(note: CommissionNote) {
+        selectedNote.value = note;
+        isPanelOpen.value = true;
+    }
+
+    function openCreate() {
+        selectedNote.value = null;
+        isPanelOpen.value = true;
+    }
+
+    function closePanel() {
+        selectedNote.value = null;
+        isPanelOpen.value = false;
+    }
+
+    function setFilter(employeeId: number | null) {
+        filterEmployeeId.value = employeeId;
+    }
+
+    return {
+        selectedNote,
+        isPanelOpen,
+        filterEmployeeId,
+        selectNote,
+        openCreate,
+        closePanel,
+        setFilter,
+    };
+});

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -33,5 +33,19 @@ export type Auth = {
     user: User;
     companies: Company[];
     selectedCompanyId: number | null;
+    branches: Branch[];
     roles: string[];
+};
+
+export type CommissionNote = {
+    id: number;
+    company_id: number;
+    branch_id: number;
+    employee_id: number;
+    created_by: number;
+    amount: string; // decimal cast serialises as string
+    description: string | null;
+    payment_date: string;
+    employee?: Employee;
+    author?: Pick<User, 'id' | 'name'>;
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\CommissionNoteController;
 use App\Http\Controllers\CompanySwitchController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -27,4 +28,15 @@ Route::post('/company/switch', [CompanySwitchController::class, 'store'])
 Route::middleware(['auth', 'role:manager'])->group(function () {
     Route::get('/users', [UserController::class, 'index'])->name('users.index');
     Route::post('/users', [UserController::class, 'store'])->name('users.store');
+});
+
+Route::middleware(['auth'])->group(function () {
+    Route::get('/companies/{company}/branches/{branch}/notes',
+        [CommissionNoteController::class, 'index'])->name('notes.index');
+    Route::post('/companies/{company}/branches/{branch}/notes',
+        [CommissionNoteController::class, 'store'])->name('notes.store');
+    Route::patch('/notes/{note}',
+        [CommissionNoteController::class, 'update'])->name('notes.update');
+    Route::delete('/notes/{note}',
+        [CommissionNoteController::class, 'destroy'])->name('notes.destroy');
 });


### PR DESCRIPTION
Closes #29

## Summary
- Adds CommissionNoteController, CommissionNoteService, and form requests for full commission note CRUD (index, store, update, destroy)
- Routes scoped to /companies/{company}/branches/{branch}/notes with permission checks via AuthorizesRequests
- AppLayout navigation now shows a Commission Notes link per branch (dropdown for multiple branches), powered by branches shared through HandleInertiaRequests
- CommissionNotes/Index.vue page with a data table, employee filter, and slideover create/edit form
- 
oteStore Pinia store managing panel open/close and note selection state

## Test plan
- [ ] Log in as a manager; verify Commission Notes appears in the sidebar for the selected company's branches
- [ ] Create a commission note and confirm it appears in the table
- [ ] Edit an existing note (own note and as manager on others)
- [ ] Delete a note as a manager
- [ ] Verify non-managers cannot delete/edit others notes
- [ ] Confirm all 14 Pest tests still pass (php artisan test)