### PR TITLE
Add model factories and feature tests for CommissionNote

### DIFF
--- a/app/Models/Branch.php
+++ b/app/Models/Branch.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Branch extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['company_id', 'name'];
 
     public function company(): BelongsTo

--- a/app/Models/CommissionNote.php
+++ b/app/Models/CommissionNote.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class CommissionNote extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'company_id', 'branch_id', 'employee_id',
         'created_by', 'amount', 'description', 'payment_date',

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Company extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['name'];
 
     public function branches(): HasMany

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Employee extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['company_id', 'branch_id', 'user_id', 'name'];
 
     public function user(): BelongsTo

--- a/database/factories/BranchFactory.php
+++ b/database/factories/BranchFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Branch;
+use App\Models\Company;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Branch>
+ */
+class BranchFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'company_id' => Company::factory(),
+            'name' => fake()->city().' Branch',
+        ];
+    }
+}

--- a/database/factories/CommissionNoteFactory.php
+++ b/database/factories/CommissionNoteFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Branch;
+use App\Models\CommissionNote;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CommissionNote>
+ */
+class CommissionNoteFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'company_id' => Company::factory(),
+            'branch_id' => Branch::factory(),
+            'employee_id' => Employee::factory(),
+            'created_by' => User::factory(),
+            'amount' => fake()->numberBetween(1000, 50000),
+            'description' => null,
+            'payment_date' => fake()->date(),
+        ];
+    }
+}

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Company;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Company>
+ */
+class CompanyFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+        ];
+    }
+}

--- a/database/factories/EmployeeFactory.php
+++ b/database/factories/EmployeeFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Employee>
+ */
+class EmployeeFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'company_id' => Company::factory(),
+            'branch_id' => Branch::factory(),
+            'user_id' => null,
+            'name' => fake()->name(),
+        ];
+    }
+}

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -82,7 +82,7 @@ const panelUi = shallowRef({});
                 <USeparator :ui="{ border: 'border-white-100/80' }" />
                 <UNavigationMenu
                     :ui="{
-                        link: 'before:bg-transparent data-[active]:text-primary-500 text-white-50',
+                        link: 'data-[active]:text-primary-500 text-white-50',
                         linkLeadingIcon:
                             'group-data-[active]:text-primary-500 text-white-50',
                     }"

--- a/tests/Feature/CommissionNoteServiceTest.php
+++ b/tests/Feature/CommissionNoteServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\CommissionNote;
+use App\Models\User;
+use App\Services\CommissionNoteService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function () {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+    Permission::create(['name' => 'view commission notes']);
+    Permission::create(['name' => 'manage commission notes']);
+});
+
+it('allows the original author to edit their own note', function () {
+    $author = User::factory()->create();
+    $author->givePermissionTo('manage commission notes');
+
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+
+    $this->actingAs($author);
+
+    $service = new CommissionNoteService;
+    $updated = $service->update($note, [
+        'amount' => 15000,
+        'payment_date' => now()->toDateString(),
+    ]);
+
+    expect($updated->amount)->toBe('15000.00');
+});
+
+it('prevents a non-author without manage permission from editing', function () {
+    $author = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $otherUser->givePermissionTo('view commission notes');
+
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+
+    $this->actingAs($otherUser);
+
+    $service = new CommissionNoteService;
+
+    expect(fn () => $service->update($note, [
+        'amount' => 99999,
+        'payment_date' => now()->toDateString(),
+    ]))->toThrow(AuthorizationException::class);
+});
+
+it('allows a manager to edit someone elses note', function () {
+    $author = User::factory()->create();
+    $manager = User::factory()->create();
+    $manager->givePermissionTo('manage commission notes');
+
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+
+    $this->actingAs($manager);
+
+    $service = new CommissionNoteService;
+    $updated = $service->update($note, [
+        'amount' => 25000,
+        'payment_date' => now()->toDateString(),
+    ]);
+
+    expect($updated->amount)->toBe('25000.00');
+});

--- a/tests/Feature/CommissionNoteTest.php
+++ b/tests/Feature/CommissionNoteTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\User;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+beforeEach(function () {
+    app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+    Permission::create(['name' => 'view commission notes']);
+    Permission::create(['name' => 'manage commission notes']);
+});
+
+it('redirects guests away from notes', function () {
+    $company = Company::factory()->create();
+    $branch = Branch::factory()->for($company)->create();
+
+    $this->get(route('notes.index', [$company, $branch]))
+        ->assertRedirect(route('login'));
+});
+
+it('denies access to users without view permission', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    $branch = Branch::factory()->for($company)->create();
+
+    $this->actingAs($user)
+        ->get(route('notes.index', [$company, $branch]))
+        ->assertForbidden();
+});
+
+it('allows viewing notes with view permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('view commission notes');
+
+    $company = Company::factory()->create();
+    $branch = Branch::factory()->for($company)->create();
+
+    $this->actingAs($user)
+        ->get(route('notes.index', [$company, $branch]))
+        ->assertOk();
+});
+
+it('forbids creating a note with view-only permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('view commission notes');
+
+    $company = Company::factory()->create();
+    $branch = Branch::factory()->for($company)->create();
+    $employee = Employee::factory()->for($company)->for($branch)->create();
+
+    $this->actingAs($user)->post(route('notes.store', [$company, $branch]), [
+        'company_id' => $company->id,
+        'branch_id' => $branch->id,
+        'employee_id' => $employee->id,
+        'amount' => 5000,
+        'payment_date' => now()->toDateString(),
+    ])->assertForbidden();
+});
+
+it('creates a note successfully with manage permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo(['view commission notes', 'manage commission notes']);
+
+    $company = Company::factory()->create();
+    $branch = Branch::factory()->for($company)->create();
+    $employee = Employee::factory()->for($company)->for($branch)->create();
+
+    $this->actingAs($user)->post(route('notes.store', [$company, $branch]), [
+        'company_id' => $company->id,
+        'branch_id' => $branch->id,
+        'employee_id' => $employee->id,
+        'amount' => 10000,
+        'payment_date' => now()->toDateString(),
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('commission_notes', [
+        'employee_id' => $employee->id,
+        'amount' => 10000,
+    ]);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,9 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
Closes #31

## What changed

- Added HasFactory trait to Branch, Company, Employee, and CommissionNote models
- Created Eloquent factories for all four models to support test data setup
- Added CommissionNoteTest covering HTTP access control: guest redirect, forbidden without permission, 200 with view permission, 403 on store with view-only, redirect on store with manage permission
- Added CommissionNoteServiceTest covering service-layer authorization: author can edit own note, non-author without manage permission is blocked, manager can edit any note
- Fixed TestCase::setUp() to call withoutVite() so all Inertia route tests pass without a built Vite manifest (this also fixes the pre-existing AuthGuardTest failures)
- Removed redundant efore:bg-transparent Tailwind class from AppLayout navigation link