### PR TITLE
Fix requirements gaps: ASSESSMENT.md, destroy auth, update tests, store scope

### DIFF
--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -1,0 +1,56 @@
+# Assessment Notes
+
+## Assumptions
+
+### Company and branch selection
+A user belongs to one or more companies via the `employees` table (an employee record links a user to a specific company and branch). On login the application checks which companies the user is associated with and sets the first one as the `selected_company_id` in the session. A **Company Switcher** dropdown in the navigation lets the user change context at any time. Once a company is selected, only that company's branches are shown, and every commission note route is scoped under `/companies/{company}/branches/{branch}/notes`. There are no "global" notes.
+
+### Employee model
+The seeder creates `Employee` rows that link a `User` to a `Company` + `Branch`. `user_id` on `employees` is nullable so that employees who do not have a system login can still appear as payees on commission notes (useful for non-user staff added by a manager).
+
+### Data seeded to satisfy the exercise
+The seeder creates the company **Spar** with two branches (**Spar Bellville** and **Spar Gardens**), two employees in different branches (Alice Nkosi in Bellville, Bob Dlamini in Gardens), and one commission note per employee (R 10 000 and R 20 000 respectively), exactly as specified.
+
+---
+
+## Permission names
+
+| Permission | Role(s) | Meaning |
+|---|---|---|
+| `view commission notes` | viewer, manager | May open the notes UI and see notes for the selected company + branch context. |
+| `manage commission notes` | manager | May create, update, and delete commission notes. A user with this permission may also edit or delete notes authored by anyone else. |
+
+Users without either permission are denied access to the notes area entirely (HTTP 403 from `$this->authorize('view commission notes')`).
+
+---
+
+## Tradeoffs
+
+### Role-based vs. permission-based enforcement
+Spatie's permission system is used at the permission level (`can('view commission notes')`) rather than the role level (`hasRole('manager')`). This makes it easy to add new roles or reassign permissions later without touching the authorization code.
+
+### Author-bypass on edit and delete
+The spec states "only the original author may edit a note unless the user has manage commission notes". The same principle is applied to deletion — an author can delete their own note, a manager can delete anyone's note. This is enforced in `CommissionNoteService` and the controller delegates fully to the service rather than duplicating the check.
+
+### No separate API layer
+All data transfer goes through Inertia shared props and controller responses. There is no `/api` prefix or JSON-only endpoint. This keeps the surface area small for an internal tool and avoids duplicating authorization logic.
+
+### Assets built at Docker image build time
+Frontend assets (`npm run build`) are compiled inside the `Dockerfile` during `docker compose build`. This means no separate Node container is needed at runtime, and the production nginx serves pre-compiled static files. The tradeoff is a slightly longer initial build; hot-reload is not available in this Docker setup.
+
+### SQLite for tests
+Tests run against an in-memory SQLite database (configured in `phpunit.xml`), independent of the MariaDB container. This keeps the test suite fast and self-contained and means the `db` service does not need to be healthy to run tests.
+
+---
+
+## What I would harden for production
+
+| Area | Action |
+|---|---|
+| **Queued notifications** | Commission note creation/update would dispatch a `CommissionNoteCreated` event. A listener would push a `SendCommissionNotification` job onto a Redis-backed queue (`php artisan queue:work`). The job would send an email (via Laravel's `Mail` facade) or an SMS (via a gateway like BulkSMS) to the employee. This keeps the HTTP request fast and decouples delivery from the web process. |
+| **Backups** | Schedule `spatie/laravel-backup` to snapshot the MariaDB volume nightly to an off-site S3 bucket. |
+| **Rate limiting** | Apply stricter per-user throttle on the `notes.store` and `notes.update` routes. |
+| **Audit trail** | Add an `activity_log` table (or use `spatie/laravel-activitylog`) to record who created or changed each note and when. |
+| **HTTPS** | Terminate TLS at a reverse proxy (e.g. Caddy or an AWS ALB) in front of the nginx container; set `SESSION_SECURE_COOKIE=true`. |
+| **Permissions cache** | Warm the Spatie permission cache on deployment (`php artisan permission:cache-reset`) and set a reasonable TTL to avoid per-request DB hits. |
+| **Environment secrets** | Move `APP_KEY`, DB credentials, and mail credentials out of `docker-compose.yml` into a secrets manager (e.g. AWS Secrets Manager or Doppler). |

--- a/app/Http/Controllers/CommissionNoteController.php
+++ b/app/Http/Controllers/CommissionNoteController.php
@@ -50,8 +50,6 @@ class CommissionNoteController extends Controller
 
     public function destroy(CommissionNote $note): RedirectResponse
     {
-        $this->authorize('manage commission notes');
-
         $this->service->delete($note);
 
         return back()->with('success', 'Commission note deleted.');

--- a/app/Http/Requests/StoreCommissionNoteRequest.php
+++ b/app/Http/Requests/StoreCommissionNoteRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Branch;
+use App\Models\Company;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreCommissionNoteRequest extends FormRequest
@@ -9,6 +11,21 @@ class StoreCommissionNoteRequest extends FormRequest
     public function authorize(): bool
     {
         return $this->user()->can('manage commission notes');
+    }
+
+    /**
+     * Force company_id and branch_id to match the route-bound models so that
+     * a caller cannot POST a mismatched scope through the request body.
+     */
+    protected function prepareForValidation(): void
+    {
+        $company = $this->route('company');
+        $branch = $this->route('branch');
+
+        $this->merge([
+            'company_id' => $company instanceof Company ? $company->id : (int) $company,
+            'branch_id' => $branch instanceof Branch ? $branch->id : (int) $branch,
+        ]);
     }
 
     public function rules(): array

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -180,10 +180,6 @@ const panelUi = shallowRef({});
                                         class="h-6"
                                         orientation="vertical"
                                     />
-                                    <!--                                <span-->
-                                    <!--                                    v-if="pageLabel"-->
-                                    <!--                                    class="truncate text-sm font-semibold text-light-50"-->
-                                    <!--                                >{{ pageLabel }}</span>-->
                                 </div>
                             </template>
                             <template #right>
@@ -191,43 +187,16 @@ const panelUi = shallowRef({});
                                     :ui="{ leadingIcon: 'text-white-50' }"
                                     variant="link"
                                 />
-                                <!--                            <UTooltip :shortcuts="['N']" text="Notifications">-->
-                                <!--                                <UButton-->
-                                <!--                                    :disabled="workspaceLocked"-->
-                                <!--                                    color="white"-->
-                                <!--                                    square-->
-                                <!--                                    variant="link"-->
-                                <!--                                >-->
-                                <!--                                    <UChip-->
-                                <!--                                        color="error"-->
-                                <!--                                        inset-->
-                                <!--                                        @click="isNotificationsSlideoverOpen = true"-->
-                                <!--                                    >-->
-                                <!--                                        <UIcon class="size-5 shrink-0" name="i-lucide-bell" />-->
-                                <!--                                    </UChip>-->
-                                <!--                                </UButton>-->
-                                <!--                            </UTooltip>-->
                             </template>
                         </UDashboardNavbar>
                     </div>
                 </template>
                 <template #body>
-                    <div class="flex min-h-0 flex-1 flex-col">
+                    <div class="flex min-h-0 flex-1 flex-col pr-4 pl-2">
                         <slot />
                     </div>
                 </template>
             </UDashboardPanel>
-            <!--        <div class="flex min-h-screen flex-1 flex-col overflow-hidden">-->
-            <!--            <UDashboardNavbar>-->
-            <!--                <template #right>-->
-            <!--                    <UColorModeButton />-->
-            <!--                </template>-->
-            <!--            </UDashboardNavbar>-->
-
-            <!--            <main class="flex-1 overflow-y-auto p-6">-->
-            <!--                <slot />-->
-            <!--            </main>-->
-            <!--        </div>-->
         </UDashboardGroup>
     </div>
 </template>

--- a/tests/Feature/CommissionNoteTest.php
+++ b/tests/Feature/CommissionNoteTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Branch;
+use App\Models\CommissionNote;
 use App\Models\Company;
 use App\Models\Employee;
 use App\Models\User;
@@ -81,4 +82,61 @@ it('creates a note successfully with manage permission', function () {
         'employee_id' => $employee->id,
         'amount' => 10000,
     ]);
+});
+
+it('forbids updating a note the view-only user did not author', function () {
+    $author = User::factory()->create();
+    $author->givePermissionTo(['view commission notes', 'manage commission notes']);
+
+    $viewer = User::factory()->create();
+    $viewer->givePermissionTo('view commission notes');
+
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+
+    $this->actingAs($viewer)->patch(route('notes.update', $note), [
+        'amount' => 99999,
+        'payment_date' => now()->toDateString(),
+    ])->assertForbidden();
+});
+
+it('allows a view-only user to update a note they authored', function () {
+    $viewer = User::factory()->create();
+    $viewer->givePermissionTo('view commission notes');
+
+    $note = CommissionNote::factory()->create(['created_by' => $viewer->id]);
+
+    $this->actingAs($viewer)->patch(route('notes.update', $note), [
+        'amount' => 12000,
+        'payment_date' => now()->toDateString(),
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('commission_notes', [
+        'id' => $note->id,
+        'amount' => 12000,
+    ]);
+});
+
+it('forbids deleting a note the view-only user did not author', function () {
+    $author = User::factory()->create();
+    $author->givePermissionTo(['view commission notes', 'manage commission notes']);
+
+    $viewer = User::factory()->create();
+    $viewer->givePermissionTo('view commission notes');
+
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+
+    $this->actingAs($viewer)->delete(route('notes.destroy', $note))
+        ->assertForbidden();
+});
+
+it('allows the original author to delete their own note', function () {
+    $author = User::factory()->create();
+    $author->givePermissionTo('view commission notes');
+
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+
+    $this->actingAs($author)->delete(route('notes.destroy', $note))
+        ->assertRedirect();
+
+    $this->assertDatabaseMissing('commission_notes', ['id' => $note->id]);
 });


### PR DESCRIPTION
Closes #33

## Summary

- **docs** — Add ASSESSMENT.md (mandatory deliverable): assumptions on company/branch context selection, permission names and meanings, architectural tradeoffs, and production hardening notes including a queued-notification design note.
- **bugfix** — Remove redundant \->authorize('manage commission notes') from CommissionNoteController::destroy; the service already enforces author-or-manager, and the controller check was silently blocking authors from deleting their own notes despite the frontend showing them the Delete button.
- **test** — Add four HTTP feature tests: non-author viewer gets 403 on PATCH and DELETE; original author can update and delete their own note (assertRedirect + assertDatabaseHas/Missing).
- **security** — Override prepareForValidation in StoreCommissionNoteRequest to lock company_id and ranch_id to the route-bound URL segments, preventing a caller from creating a misscoped note by supplying different IDs in the request body. Handles both raw-string and model-bound route param cases.

All 26 tests pass (composer ci:check green).