### PR TITLE
Implement feature gap: policy, soft deletes, pagination, validation, tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 APP_NAME=Laravel
 APP_ENV=local
+# Generate with: php artisan key:generate
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
@@ -20,12 +21,27 @@ LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
+# ── Local development (SQLite) ────────────────────────────────────────────────
 DB_CONNECTION=sqlite
 # DB_HOST=127.0.0.1
 # DB_PORT=3306
 # DB_DATABASE=laravel
 # DB_USERNAME=root
 # DB_PASSWORD=
+
+# ── Docker / MariaDB ──────────────────────────────────────────────────────────
+# When running via `docker compose up`, uncomment these and comment out the
+# SQLite block above.
+#
+# DB_CONNECTION=mysql
+# DB_HOST=db               # matches the service name in docker-compose.yml
+# DB_PORT=3306
+# DB_DATABASE=earn_wise_db
+# DB_USERNAME=earn_wise_user
+# DB_PASSWORD=secret
+#
+# The MariaDB container also needs:
+# MYSQL_ROOT_PASSWORD=rootsecret   # set in docker-compose.yml; change for prod
 
 SESSION_DRIVER=database
 SESSION_LIFETIME=120

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: up down seed test shell logs
+
+up:
+	docker compose up --build -d
+
+down:
+	docker compose down
+
+seed:
+	docker compose exec app php artisan migrate:fresh --seed
+
+test:
+	docker compose exec app vendor/bin/pest
+
+shell:
+	docker compose exec app bash
+
+logs:
+	docker compose logs -f app

--- a/app/Http/Controllers/CommissionNoteController.php
+++ b/app/Http/Controllers/CommissionNoteController.php
@@ -10,6 +10,7 @@ use App\Models\Company;
 use App\Models\User;
 use App\Services\CommissionNoteService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -18,9 +19,9 @@ class CommissionNoteController extends Controller
 {
     public function __construct(private CommissionNoteService $service) {}
 
-    public function index(Company $company, Branch $branch): Response
+    public function index(Company $company, Branch $branch, Request $request): Response
     {
-        $this->authorize('view commission notes');
+        $this->authorize('viewAny', CommissionNote::class);
 
         /** @var User $user */
         $user = Auth::user();
@@ -28,9 +29,10 @@ class CommissionNoteController extends Controller
         return Inertia::render('CommissionNotes/Index', [
             'company' => $company,
             'branch' => $branch,
-            'notes' => $this->service->list($company->id, $branch->id),
+            'notes' => $this->service->list($company->id, $branch->id, $request->query('search')),
             'employees' => $branch->employees,
             'canManage' => $user->can('manage commission notes'),
+            'filters' => ['search' => $request->query('search', '')],
         ]);
     }
 
@@ -43,6 +45,8 @@ class CommissionNoteController extends Controller
 
     public function update(UpdateCommissionNoteRequest $request, CommissionNote $note): RedirectResponse
     {
+        $this->authorize('update', $note);
+
         $this->service->update($note, $request->validated());
 
         return back()->with('success', 'Commission note updated.');
@@ -50,8 +54,19 @@ class CommissionNoteController extends Controller
 
     public function destroy(CommissionNote $note): RedirectResponse
     {
+        $this->authorize('delete', $note);
+
         $this->service->delete($note);
 
         return back()->with('success', 'Commission note deleted.');
+    }
+
+    public function restore(CommissionNote $note): RedirectResponse
+    {
+        $this->authorize('restore', $note);
+
+        $this->service->restore($note);
+
+        return back()->with('success', 'Commission note restored.');
     }
 }

--- a/app/Http/Requests/StoreCommissionNoteRequest.php
+++ b/app/Http/Requests/StoreCommissionNoteRequest.php
@@ -3,14 +3,16 @@
 namespace App\Http\Requests;
 
 use App\Models\Branch;
+use App\Models\CommissionNote;
 use App\Models\Company;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreCommissionNoteRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->can('manage commission notes');
+        return $this->user()->can('create', CommissionNote::class);
     }
 
     /**
@@ -33,7 +35,13 @@ class StoreCommissionNoteRequest extends FormRequest
         return [
             'company_id' => ['required', 'integer', 'exists:companies,id'],
             'branch_id' => ['required', 'integer', 'exists:branches,id'],
-            'employee_id' => ['required', 'integer', 'exists:employees,id'],
+            'employee_id' => [
+                'required',
+                'integer',
+                Rule::exists('employees', 'id')->where(fn ($q) => $q->where('branch_id', $this->branch_id)
+                    ->where('company_id', $this->company_id)
+                ),
+            ],
             'amount' => ['required', 'numeric', 'min:0'],
             'description' => ['nullable', 'string', 'max:1000'],
             'payment_date' => ['required', 'date'],

--- a/app/Http/Requests/UpdateCommissionNoteRequest.php
+++ b/app/Http/Requests/UpdateCommissionNoteRequest.php
@@ -2,14 +2,17 @@
 
 namespace App\Http\Requests;
 
+use App\Models\CommissionNote;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateCommissionNoteRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->can('manage commission notes')
-            || $this->route('note')->created_by === $this->user()->id;
+        /** @var CommissionNote $note */
+        $note = $this->route('note');
+
+        return $this->user()->can('update', $note);
     }
 
     public function rules(): array

--- a/app/Models/CommissionNote.php
+++ b/app/Models/CommissionNote.php
@@ -6,10 +6,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class CommissionNote extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'company_id', 'branch_id', 'employee_id',

--- a/app/Policies/CommissionNotePolicy.php
+++ b/app/Policies/CommissionNotePolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CommissionNote;
+use App\Models\User;
+
+class CommissionNotePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view commission notes');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('manage commission notes');
+    }
+
+    public function update(User $user, CommissionNote $note): bool
+    {
+        return $user->can('manage commission notes')
+            || $note->created_by === $user->id;
+    }
+
+    public function delete(User $user, CommissionNote $note): bool
+    {
+        return $user->can('manage commission notes')
+            || $note->created_by === $user->id;
+    }
+
+    public function restore(User $user, CommissionNote $note): bool
+    {
+        return $user->can('manage commission notes');
+    }
+}

--- a/app/Services/CommissionNoteService.php
+++ b/app/Services/CommissionNoteService.php
@@ -5,20 +5,21 @@ namespace App\Services;
 use App\Events\CommissionNoteCreated;
 use App\Models\CommissionNote;
 use App\Models\CommissionNoteAudit;
-use App\Models\User;
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Auth;
 
 class CommissionNoteService
 {
-    public function list(int $companyId, int $branchId): Collection
+    public function list(int $companyId, int $branchId, ?string $search = null): LengthAwarePaginator
     {
         return CommissionNote::with(['employee', 'author', 'audits.actor'])
             ->where('company_id', $companyId)
             ->where('branch_id', $branchId)
+            ->when($search, fn ($q) => $q->whereHas('employee',
+                fn ($q) => $q->where('name', 'like', "%{$search}%")
+            ))
             ->latest()
-            ->get();
+            ->paginate(15);
     }
 
     public function create(array $validated): CommissionNote
@@ -42,13 +43,6 @@ class CommissionNoteService
 
     public function update(CommissionNote $note, array $validated): CommissionNote
     {
-        /** @var User $user */
-        $user = Auth::user();
-
-        if ($note->created_by !== $user->id && ! $user->can('manage commission notes')) {
-            throw new AuthorizationException('You are not authorised to edit this note.');
-        }
-
         $oldValues = $this->auditableValues($note);
 
         $note->update([
@@ -66,16 +60,18 @@ class CommissionNoteService
 
     public function delete(CommissionNote $note): void
     {
-        /** @var User $user */
-        $user = Auth::user();
-
-        if ($note->created_by !== $user->id && ! $user->can('manage commission notes')) {
-            throw new AuthorizationException('You are not authorised to delete this note.');
-        }
-
         $this->recordAudit('deleted', $note->id, $this->auditableValues($note), null);
 
         $note->delete();
+    }
+
+    public function restore(CommissionNote $note): CommissionNote
+    {
+        $note->restore();
+
+        $this->recordAudit('created', $note->id, null, $this->auditableValues($note));
+
+        return $note;
     }
 
     /** @return array<string, mixed> */

--- a/database/migrations/2026_04_26_160000_add_soft_deletes_to_commission_notes_table.php
+++ b/database/migrations/2026_04_26_160000_add_soft_deletes_to_commission_notes_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('commission_notes', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('commission_notes', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/resources/js/pages/CommissionNotes/Index.vue
+++ b/resources/js/pages/CommissionNotes/Index.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { Head, router, useForm, usePage } from '@inertiajs/vue3';
+import { useDebounceFn } from '@vueuse/core';
 import { computed, h, ref, resolveComponent, watch } from 'vue';
 import {
     destroy as destroyAction,
+    index as indexAction,
     store as storeAction,
     update as updateAction,
 } from '@/actions/App/Http/Controllers/CommissionNoteController';
@@ -14,6 +16,7 @@ import type {
     CommissionNoteAudit,
     Company,
     Employee,
+    Paginated,
 } from '@/types/auth';
 
 defineOptions({ layout: AppLayout });
@@ -21,9 +24,10 @@ defineOptions({ layout: AppLayout });
 const props = defineProps<{
     company: Company;
     branch: Branch;
-    notes: CommissionNote[];
+    notes: Paginated<CommissionNote>;
     employees: Employee[];
     canManage: boolean;
+    filters: { search: string };
 }>();
 
 const page = usePage();
@@ -33,18 +37,17 @@ const currentUserId = computed(
     () => (page.props.auth as any)?.user?.id as number,
 );
 
-const filteredNotes = computed(() =>
-    noteStore.filterEmployeeId
-        ? props.notes.filter(
-              (n) => n.employee_id === noteStore.filterEmployeeId,
-          )
-        : props.notes,
-);
+const search = ref(props.filters.search ?? '');
 
-const employeeItems = computed(() => [
-    { label: 'All Employees', value: null },
-    ...props.employees.map((e) => ({ label: e.name, value: e.id })),
-]);
+const performSearch = useDebounceFn((value: string) => {
+    router.get(
+        indexAction.url({ company: props.company.id, branch: props.branch.id }),
+        { search: value || undefined },
+        { preserveState: true, replace: true },
+    );
+}, 400);
+
+watch(search, (value) => performSearch(value));
 
 // ── Export URL ────────────────────────────────────────────────────────────────
 
@@ -280,21 +283,34 @@ const columns = [
             </div>
         </div>
 
-        <!-- Employee filter -->
+        <!-- Search -->
         <div class="flex items-center gap-3">
-            <USelect
-                :items="employeeItems"
-                :model-value="noteStore.filterEmployeeId"
-                placeholder="Filter by employee"
-                class="w-56"
-                @update:model-value="noteStore.setFilter($event)"
-            />
+            <UInput
+                v-model="search"
+                placeholder="Search by employee name…"
+                icon="i-lucide-search"
+                class="w-72"
+                :ui="{ trailing: 'pr-1' }"
+            >
+                <template v-if="search" #trailing>
+                    <UButton
+                        color="neutral"
+                        variant="link"
+                        size="sm"
+                        icon="i-lucide-x"
+                        @click="search = ''"
+                    />
+                </template>
+            </UInput>
+            <span class="text-sm text-muted">
+                {{ notes.total }} note{{ notes.total !== 1 ? 's' : '' }}
+            </span>
         </div>
 
         <!-- Notes table -->
         <UCard>
             <UTable
-                :data="filteredNotes"
+                :data="notes.data"
                 :columns="columns"
                 empty="No commission notes found."
             >
@@ -335,6 +351,29 @@ const columns = [
                     </div>
                 </template>
             </UTable>
+
+            <!-- Pagination -->
+            <div
+                v-if="notes.last_page > 1"
+                class="mt-4 flex justify-center border-t pt-4"
+            >
+                <UPagination
+                    :page="notes.current_page"
+                    :total="notes.total"
+                    :items-per-page="notes.per_page"
+                    @update:page="
+                        (p: number) =>
+                            router.get(
+                                indexAction.url({
+                                    company: company.id,
+                                    branch: branch.id,
+                                }),
+                                { page: p, search: search || undefined },
+                                { preserveState: true },
+                            )
+                    "
+                />
+            </div>
         </UCard>
     </div>
 

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -98,3 +98,20 @@ export type RecentNote = {
     branch_name: string | null;
     author_name: string | null;
 };
+
+export type PaginatedLink = {
+    url: string | null;
+    label: string;
+    active: boolean;
+};
+
+export type Paginated<T> = {
+    data: T[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+    links: PaginatedLink[];
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,6 +52,12 @@ Route::middleware(['auth'])->group(function () {
         ->name('notes.destroy')
         ->middleware('throttle:commission-writes');
 
+    Route::patch('/notes/{note}/restore',
+        [CommissionNoteController::class, 'restore'])
+        ->name('notes.restore')
+        ->withTrashed()
+        ->middleware('throttle:commission-writes');
+
     Route::get('/companies/{company}/branches/{branch}/notes/export',
         CommissionNoteExportController::class)->name('notes.export');
 

--- a/tests/Feature/CommissionNoteAuditTest.php
+++ b/tests/Feature/CommissionNoteAuditTest.php
@@ -94,7 +94,7 @@ it('records a deleted audit entry when a note is deleted', function () {
     $service = new CommissionNoteService;
     $service->delete($note);
 
-    $this->assertDatabaseMissing('commission_notes', ['id' => $noteId]);
+    $this->assertSoftDeleted('commission_notes', ['id' => $noteId]);
 
     $audit = CommissionNoteAudit::where('commission_note_id', $noteId)
         ->where('event', 'deleted')

--- a/tests/Feature/CommissionNoteServiceTest.php
+++ b/tests/Feature/CommissionNoteServiceTest.php
@@ -3,7 +3,6 @@
 use App\Models\CommissionNote;
 use App\Models\User;
 use App\Services\CommissionNoteService;
-use Illuminate\Auth\Access\AuthorizationException;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -29,23 +28,6 @@ it('allows the original author to edit their own note', function () {
     ]);
 
     expect($updated->amount)->toBe('15000.00');
-});
-
-it('prevents a non-author without manage permission from editing', function () {
-    $author = User::factory()->create();
-    $otherUser = User::factory()->create();
-    $otherUser->givePermissionTo('view commission notes');
-
-    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
-
-    $this->actingAs($otherUser);
-
-    $service = new CommissionNoteService;
-
-    expect(fn () => $service->update($note, [
-        'amount' => 99999,
-        'payment_date' => now()->toDateString(),
-    ]))->toThrow(AuthorizationException::class);
 });
 
 it('allows a manager to edit someone elses note', function () {

--- a/tests/Feature/CommissionNoteTest.php
+++ b/tests/Feature/CommissionNoteTest.php
@@ -138,5 +138,58 @@ it('allows the original author to delete their own note', function () {
     $this->actingAs($author)->delete(route('notes.destroy', $note))
         ->assertRedirect();
 
-    $this->assertDatabaseMissing('commission_notes', ['id' => $note->id]);
+    $this->assertSoftDeleted('commission_notes', ['id' => $note->id]);
+});
+
+it('does not return notes from other branches', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('view commission notes');
+
+    $company = Company::factory()->create();
+    $branchA = Branch::factory()->for($company)->create();
+    $branchB = Branch::factory()->for($company)->create();
+    $employee = Employee::factory()->for($company)->for($branchA)->create();
+
+    $note = CommissionNote::factory()->create([
+        'company_id' => $company->id,
+        'branch_id' => $branchA->id,
+        'employee_id' => $employee->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('notes.index', [$company, $branchB]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('CommissionNotes/Index')
+            ->where('notes.data', fn ($notes) => collect($notes)->pluck('id')->doesntContain($note->id)
+            )
+        );
+});
+
+it('rejects negative commission amounts', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo(['view commission notes', 'manage commission notes']);
+
+    $company = Company::factory()->create();
+    $branch = Branch::factory()->for($company)->create();
+    $employee = Employee::factory()->for($company)->for($branch)->create();
+
+    $this->actingAs($user)->post(route('notes.store', [$company, $branch]), [
+        'employee_id' => $employee->id,
+        'amount' => -100,
+        'payment_date' => now()->toDateString(),
+    ])->assertSessionHasErrors('amount');
+});
+
+it('returns 404 when patching a soft-deleted note', function () {
+    $author = User::factory()->create();
+    $author->givePermissionTo(['view commission notes', 'manage commission notes']);
+
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+    $note->delete();
+
+    $this->actingAs($author)->patch(route('notes.update', $note->id), [
+        'amount' => 500,
+        'payment_date' => now()->toDateString(),
+    ])->assertNotFound();
 });


### PR DESCRIPTION
Closes #37

## Summary

- **CommissionNotePolicy** — dedicated policy class (viewAny/create/update/delete/restore) replaces inline Spatie permission strings in controller and form requests; service no longer throws AuthorizationException
- **Branch-scoped employee validation** — StoreCommissionNoteRequest uses Rule::exists()->where() to ensure the selected employee belongs to the correct branch and company
- **Soft deletes + restore** — SoftDeletes on CommissionNote, deleted_at migration, restore() service method, PATCH /notes/{note}/restore controller action with withTrashed() route binding; hard deletes disabled for audit compliance
- **Extra Pest tests** — cross-branch contamination (assertInertia), negative amount rejection (assertSessionHasErrors), 404 on patching a soft-deleted note; existing delete tests updated to assertSoftDeleted
- **Pagination + search** — CommissionNoteService::list() returns LengthAwarePaginator with optional employee name search; debounced UInput search field + UPagination on notes index; Paginated<T> generic type added to auth.ts
- **Makefile** — up/down/seed/test/shell/logs targets for Docker workflow
- **.env.example** — Docker/MariaDB variables documented with inline comments