### PR TITLE
Fix Dockerfile FromAsCasing warnings

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine as node-build
+FROM node:20-alpine AS node-build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --prefer-offline
 COPY resources/ ./resources/
 RUN npm run build || echo "No build script"
 
-FROM composer:2 as composer-deps
+FROM composer:2 AS composer-deps
 WORKDIR /app
 COPY composer.json composer.lock ./
 RUN composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts


### PR DESCRIPTION
Closes #41

BuildKit's linter reports `FromAsCasing` warnings when the `AS` keyword in a multi-stage `FROM` instruction does not match the casing of `FROM`. Both stage definitions used lowercase `as` instead of the required uppercase `AS`.

Changed:
- `FROM node:20-alpine as node-build` -> `FROM node:20-alpine AS node-build`
- `FROM composer:2 as composer-deps` -> `FROM composer:2 AS composer-deps`