### PR TITLE
Update npm dependencies (iconify, eslint peer deps)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,7 @@
             "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
@@ -144,6 +145,7 @@
             "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -730,6 +732,16 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -910,9 +922,9 @@
             }
         },
         "node_modules/@iconify/collections": {
-            "version": "1.0.674",
-            "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.674.tgz",
-            "integrity": "sha512-YLEpD2DufdlvG6keWnfyBL+FrIOxm2+2aypAVns9vZCBMvWSU4dn/gQEz9CV7k5QPM1uE9OQqfHAaBMR+kf1kg==",
+            "version": "1.0.676",
+            "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.676.tgz",
+            "integrity": "sha512-dtV8s0QtP0fjsIZoCA4gURBp2DWGs7vJDz+Kh5+vpeNinBbtbNz+MABDz61ikcFGE27mdvNFmA3ygprBXHZJ4A==",
             "license": "MIT",
             "dependencies": {
                 "@iconify/types": "*"
@@ -925,14 +937,14 @@
             "license": "MIT"
         },
         "node_modules/@iconify/utils": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
-            "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.1.tgz",
+            "integrity": "sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==",
             "license": "MIT",
             "dependencies": {
                 "@antfu/install-pkg": "^1.1.0",
                 "@iconify/types": "^2.0.0",
-                "mlly": "^1.8.0"
+                "mlly": "^1.8.2"
             }
         },
         "node_modules/@iconify/vue": {
@@ -1206,15 +1218,6 @@
                 "node": ">=18.12.0"
             }
         },
-        "node_modules/@nuxt/kit/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/@nuxt/schema": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.2.tgz",
@@ -1238,49 +1241,49 @@
             "license": "MIT"
         },
         "node_modules/@nuxt/ui": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.6.1.tgz",
-            "integrity": "sha512-mBbBTaVDTR6ohOoAJUiV4T2RPXo2hyLewGPTiHjy1arzHPNFnmb/Tkl/2/JipF3Y8cahV4LhVUdkWKsdgI1OXw==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.7.0.tgz",
+            "integrity": "sha512-4EDxK6XhX5kq7EuSTdV2QKmDS3hUPfSGdjeOP9SXDgNB5N/GH7qY1ryAHGUgv2o3FUuVBPBWHhz30BI1lwNK8Q==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.6",
                 "@iconify/vue": "^5.0.0",
-                "@internationalized/date": "^3.12.0",
-                "@internationalized/number": "^3.6.5",
+                "@internationalized/date": "^3.12.1",
+                "@internationalized/number": "^3.6.6",
                 "@nuxt/fonts": "^0.14.0",
                 "@nuxt/icon": "^2.2.1",
                 "@nuxt/kit": "^4.4.2",
                 "@nuxt/schema": "^4.4.2",
                 "@nuxtjs/color-mode": "^3.5.2",
                 "@standard-schema/spec": "^1.1.0",
-                "@tailwindcss/postcss": "^4.2.2",
-                "@tailwindcss/vite": "^4.2.2",
+                "@tailwindcss/postcss": "^4.2.4",
+                "@tailwindcss/vite": "^4.2.4",
                 "@tanstack/vue-table": "^8.21.3",
-                "@tanstack/vue-virtual": "^3.13.23",
-                "@tiptap/core": "^3.21.0",
-                "@tiptap/extension-bubble-menu": "^3.21.0",
-                "@tiptap/extension-code": "^3.21.0",
-                "@tiptap/extension-collaboration": "^3.21.0",
-                "@tiptap/extension-drag-handle": "^3.21.0",
-                "@tiptap/extension-drag-handle-vue-3": "^3.21.0",
-                "@tiptap/extension-floating-menu": "^3.21.0",
-                "@tiptap/extension-horizontal-rule": "^3.21.0",
-                "@tiptap/extension-image": "^3.21.0",
-                "@tiptap/extension-mention": "^3.21.0",
-                "@tiptap/extension-node-range": "^3.21.0",
-                "@tiptap/extension-placeholder": "^3.21.0",
-                "@tiptap/markdown": "^3.21.0",
-                "@tiptap/pm": "^3.21.0",
-                "@tiptap/starter-kit": "^3.21.0",
-                "@tiptap/suggestion": "^3.21.0",
-                "@tiptap/vue-3": "^3.21.0",
-                "@unhead/vue": "^2.1.12",
+                "@tanstack/vue-virtual": "^3.13.24",
+                "@tiptap/core": "^3.22.4",
+                "@tiptap/extension-bubble-menu": "^3.22.4",
+                "@tiptap/extension-code": "^3.22.4",
+                "@tiptap/extension-collaboration": "^3.22.4",
+                "@tiptap/extension-drag-handle": "^3.22.4",
+                "@tiptap/extension-drag-handle-vue-3": "^3.22.4",
+                "@tiptap/extension-floating-menu": "^3.22.4",
+                "@tiptap/extension-horizontal-rule": "^3.22.4",
+                "@tiptap/extension-image": "^3.22.4",
+                "@tiptap/extension-mention": "^3.22.4",
+                "@tiptap/extension-node-range": "^3.22.4",
+                "@tiptap/extension-placeholder": "^3.22.4",
+                "@tiptap/markdown": "^3.22.4",
+                "@tiptap/pm": "^3.22.4",
+                "@tiptap/starter-kit": "^3.22.4",
+                "@tiptap/suggestion": "^3.22.4",
+                "@tiptap/vue-3": "^3.22.4",
+                "@unhead/vue": "^2.1.13",
                 "@vueuse/core": "^14.2.1",
                 "@vueuse/integrations": "^14.2.1",
                 "@vueuse/shared": "^14.2.1",
                 "colortranslator": "^5.0.0",
                 "consola": "^3.4.2",
-                "defu": "^6.1.4",
+                "defu": "^6.1.7",
                 "embla-carousel-auto-height": "^8.6.0",
                 "embla-carousel-auto-scroll": "^8.6.0",
                 "embla-carousel-autoplay": "^8.6.0",
@@ -1288,26 +1291,26 @@
                 "embla-carousel-fade": "^8.6.0",
                 "embla-carousel-vue": "^8.6.0",
                 "embla-carousel-wheel-gestures": "^8.1.0",
-                "fuse.js": "^7.1.0",
-                "hookable": "^6.1.0",
+                "fuse.js": "^7.3.0",
+                "hookable": "^6.1.1",
                 "knitwork": "^1.3.0",
                 "magic-string": "^0.30.21",
                 "mlly": "^1.8.2",
-                "motion-v": "^2.2.0",
+                "motion-v": "^2.2.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "reka-ui": "2.9.3",
+                "reka-ui": "2.9.6",
                 "scule": "^1.3.0",
                 "tailwind-merge": "^3.5.0",
                 "tailwind-variants": "^3.2.2",
-                "tailwindcss": "^4.2.2",
-                "tinyglobby": "^0.2.15",
+                "tailwindcss": "^4.2.4",
+                "tinyglobby": "^0.2.16",
                 "ufo": "^1.6.3",
                 "unplugin": "^3.0.0",
                 "unplugin-auto-import": "^21.0.0",
                 "unplugin-vue-components": "^32.0.0",
                 "vaul-vue": "0.4.1",
-                "vue-component-type-helpers": "^3.2.6"
+                "vue-component-type-helpers": "^3.2.7"
             },
             "bin": {
                 "nuxt-ui": "cli/index.mjs"
@@ -1317,6 +1320,8 @@
             },
             "peerDependencies": {
                 "@inertiajs/vue3": "^2.0.7 || ^3.0.0",
+                "@internationalized/date": "^3.0.0",
+                "@internationalized/number": "^3.0.0",
                 "@nuxt/content": "^3.0.0",
                 "joi": "^18.0.0",
                 "superstruct": "^2.0.0",
@@ -1329,6 +1334,12 @@
             },
             "peerDependenciesMeta": {
                 "@inertiajs/vue3": {
+                    "optional": true
+                },
+                "@internationalized/date": {
+                    "optional": true
+                },
+                "@internationalized/number": {
                     "optional": true
                 },
                 "@nuxt/content": {
@@ -1378,18 +1389,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@nuxt/ui/node_modules/@vueuse/shared": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
-            "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
             }
         },
         "node_modules/@nuxtjs/color-mode": {
@@ -1453,15 +1452,6 @@
                 "pathe": "^2.0.3"
             }
         },
-        "node_modules/@nuxtjs/color-mode/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/@nuxtjs/color-mode/node_modules/pathe": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -1492,9 +1482,9 @@
             "license": "MIT"
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.126.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-            "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+            "version": "0.127.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
@@ -1507,9 +1497,9 @@
             "license": "MIT"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1523,9 +1513,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
             "cpu": [
                 "arm64"
             ],
@@ -1539,9 +1529,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
             "cpu": [
                 "x64"
             ],
@@ -1555,9 +1545,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
             "cpu": [
                 "x64"
             ],
@@ -1571,9 +1561,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-            "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
             "cpu": [
                 "arm"
             ],
@@ -1587,9 +1577,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1603,9 +1593,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-            "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
             "cpu": [
                 "arm64"
             ],
@@ -1619,9 +1609,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1635,9 +1625,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
             "cpu": [
                 "s390x"
             ],
@@ -1651,9 +1641,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
             "cpu": [
                 "x64"
             ],
@@ -1667,9 +1657,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-            "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
             "cpu": [
                 "x64"
             ],
@@ -1683,9 +1673,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
             "cpu": [
                 "arm64"
             ],
@@ -1699,17 +1689,17 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-            "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.9.2",
-                "@emnapi/runtime": "1.9.2",
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
                 "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
@@ -1735,9 +1725,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-            "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
             "cpu": [
                 "arm64"
             ],
@@ -1751,9 +1741,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-            "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
             "cpu": [
                 "x64"
             ],
@@ -2819,16 +2809,6 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/@typescript-eslint/parser": {
             "version": "8.59.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
@@ -3365,53 +3345,65 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-            "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+            "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.2",
-                "@vue/shared": "3.5.32",
+                "@vue/shared": "3.5.33",
                 "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
+        "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
+        },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-            "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+            "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.32",
-                "@vue/shared": "3.5.32"
+                "@vue/compiler-core": "3.5.33",
+                "@vue/shared": "3.5.33"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-            "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+            "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.2",
-                "@vue/compiler-core": "3.5.32",
-                "@vue/compiler-dom": "3.5.32",
-                "@vue/compiler-ssr": "3.5.32",
-                "@vue/shared": "3.5.32",
+                "@vue/compiler-core": "3.5.33",
+                "@vue/compiler-dom": "3.5.33",
+                "@vue/compiler-ssr": "3.5.33",
+                "@vue/shared": "3.5.33",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.8",
+                "postcss": "^8.5.10",
                 "source-map-js": "^1.2.1"
             }
         },
+        "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
+        },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-            "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+            "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.32",
-                "@vue/shared": "3.5.32"
+                "@vue/compiler-dom": "3.5.33",
+                "@vue/shared": "3.5.33"
             }
         },
         "node_modules/@vue/compiler-vue2": {
@@ -3555,53 +3547,53 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
-            "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+            "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.32"
+                "@vue/shared": "3.5.33"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
-            "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+            "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.32",
-                "@vue/shared": "3.5.32"
+                "@vue/reactivity": "3.5.33",
+                "@vue/shared": "3.5.33"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
-            "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+            "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.32",
-                "@vue/runtime-core": "3.5.32",
-                "@vue/shared": "3.5.32",
+                "@vue/reactivity": "3.5.33",
+                "@vue/runtime-core": "3.5.33",
+                "@vue/shared": "3.5.33",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
-            "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+            "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.32",
-                "@vue/shared": "3.5.32"
+                "@vue/compiler-ssr": "3.5.33",
+                "@vue/shared": "3.5.33"
             },
             "peerDependencies": {
-                "vue": "3.5.32"
+                "vue": "3.5.33"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-            "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+            "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
             "license": "MIT"
         },
         "node_modules/@vueuse/core": {
@@ -3614,6 +3606,18 @@
                 "@types/web-bluetooth": "^0.0.21",
                 "@vueuse/metadata": "12.8.2",
                 "@vueuse/shared": "12.8.2",
+                "vue": "^3.5.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@vueuse/core/node_modules/@vueuse/shared": {
+            "version": "12.8.2",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+            "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+            "license": "MIT",
+            "dependencies": {
                 "vue": "^3.5.13"
             },
             "funding": {
@@ -3712,18 +3716,6 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
-        "node_modules/@vueuse/integrations/node_modules/@vueuse/shared": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
-            "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
-            }
-        },
         "node_modules/@vueuse/metadata": {
             "version": "12.8.2",
             "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
@@ -3734,15 +3726,15 @@
             }
         },
         "node_modules/@vueuse/shared": {
-            "version": "12.8.2",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
-            "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+            "version": "14.2.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
+            "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
             "license": "MIT",
-            "dependencies": {
-                "vue": "^3.5.13"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
             }
         },
         "node_modules/acorn": {
@@ -3769,9 +3761,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4660,13 +4652,13 @@
             "license": "MIT"
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.20.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-            "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+            "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.0"
+                "tapable": "^2.3.3"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -4840,9 +4832,9 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.45.1",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-            "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+            "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
             "license": "MIT",
             "workspaces": [
                 "docs",
@@ -5346,6 +5338,16 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/eslint/node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/eslint/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5414,10 +5416,13 @@
             }
         },
         "node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "license": "MIT"
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
         },
         "node_modules/esutils": {
             "version": "2.0.3",
@@ -6103,10 +6108,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "dev": true,
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -7106,15 +7110,6 @@
                 "unplugin": "^2.0.0"
             }
         },
-        "node_modules/magic-regexp/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
         "node_modules/magic-regexp/node_modules/unplugin": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
@@ -7822,9 +7817,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.10",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8239,9 +8234,9 @@
             }
         },
         "node_modules/reka-ui": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.9.3.tgz",
-            "integrity": "sha512-C9lCVxsSC7uYD0Nbgik1+14FNndHNprZmf0zGQt0ZDYIt5KxXV3zD0hEqNcfRUsEEJvVmoRsUkJnASBVBeaaUw==",
+            "version": "2.9.6",
+            "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.9.6.tgz",
+            "integrity": "sha512-K6bL457owpvWONc7hsjFxo3HDC9s6IzhRqShW0w9JSKelPGfRbkHD558UQTn/NH1cvrXVHygKyC7fExFmRketg==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.13",
@@ -8252,7 +8247,7 @@
                 "@vueuse/core": "^14.1.0",
                 "@vueuse/shared": "^14.1.0",
                 "aria-hidden": "^1.2.4",
-                "defu": "^6.1.4",
+                "defu": "^6.1.5",
                 "ohash": "^2.0.11"
             },
             "funding": {
@@ -8287,18 +8282,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/reka-ui/node_modules/@vueuse/shared": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
-            "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
             }
         },
         "node_modules/require-directory": {
@@ -8372,13 +8355,13 @@
             "license": "MIT"
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.126.0",
-                "@rolldown/pluginutils": "1.0.0-rc.16"
+                "@oxc-project/types": "=0.127.0",
+                "@rolldown/pluginutils": "1.0.0-rc.17"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -8387,27 +8370,27 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
             }
         },
         "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-            "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
             "license": "MIT"
         },
         "node_modules/rope-sequence": {
@@ -9261,15 +9244,6 @@
                 "unplugin": "^2.3.11"
             }
         },
-        "node_modules/unctx/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
         "node_modules/unctx/node_modules/unplugin": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
@@ -9350,15 +9324,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/unimport/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
             }
         },
         "node_modules/unimport/node_modules/unplugin": {
@@ -9759,16 +9724,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-            "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
                 "postcss": "^8.5.10",
-                "rolldown": "1.0.0-rc.16",
+                "rolldown": "1.0.0-rc.17",
                 "tinyglobby": "^0.2.16"
             },
             "bin": {
@@ -9866,17 +9831,17 @@
             "license": "MIT"
         },
         "node_modules/vue": {
-            "version": "3.5.32",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
-            "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+            "version": "3.5.33",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+            "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.5.32",
-                "@vue/compiler-sfc": "3.5.32",
-                "@vue/runtime-dom": "3.5.32",
-                "@vue/server-renderer": "3.5.32",
-                "@vue/shared": "3.5.32"
+                "@vue/compiler-dom": "3.5.33",
+                "@vue/compiler-sfc": "3.5.33",
+                "@vue/runtime-dom": "3.5.33",
+                "@vue/server-renderer": "3.5.33",
+                "@vue/shared": "3.5.33"
             },
             "peerDependencies": {
                 "typescript": "*"


### PR DESCRIPTION
Closes #43

Bumps minor/patch npm dependencies:
- `@iconify/collections` 1.0.674 -> 1.0.676
- `@iconify/utils` 3.1.0 -> 3.1.1
- `@eslint/eslintrc`: adds peer/dev metadata flags for nested deps

Updates package-lock.json to reflect the resolved versions.