### PR TITLE
Fix CI pipeline and Docker build for frontend asset compilation

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -52,6 +52,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build
+
       - name: Generate APP_KEY
         run: echo "APP_KEY=base64:$(openssl rand -base64 32)" >> $GITHUB_ENV
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,8 +2,9 @@ FROM node:20-alpine AS node-build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --prefer-offline
+COPY vite.config.ts tsconfig.json ./
 COPY resources/ ./resources/
-RUN npm run build || echo "No build script"
+RUN npm run build
 
 FROM composer:2 AS composer-deps
 WORKDIR /app
@@ -30,6 +31,7 @@ COPY --from=composer-deps /app/composer.json ./composer.json
 
 # Copy built assets from node-build
 COPY --from=node-build /app/resources/ ./resources/
+COPY --from=node-build /app/public/build ./public/build
 COPY --from=node-build /app/node_modules ./node_modules
 
 # Copy the rest of the application source

--- a/docker/php/entrypoint.sh
+++ b/docker/php/entrypoint.sh
@@ -9,8 +9,12 @@ rm -f public/hot
 # The bind-mounted volume means the output lands on the host too, so
 # subsequent starts skip this step entirely.
 if [ ! -d public/build ] || [ -z "$(ls -A public/build 2>/dev/null)" ]; then
-    echo "[entrypoint] Building frontend assets..."
-    npm run build
+    if command -v npm > /dev/null 2>&1; then
+        echo "[entrypoint] Building frontend assets..."
+        npm run build
+    else
+        echo "[entrypoint] WARNING: npm not found, skipping frontend build. Run 'npm run build' on the host first."
+    fi
 fi
 
 exec php-fpm


### PR DESCRIPTION
Closes #45

Add missing Node.js setup and asset build steps to the CI workflow, fix the Dockerfile to correctly copy Vite config and built assets, and gracefully handle the case where npm is not available in the Docker entrypoint.