### PR TITLE
Fix vite build failure in CI due to missing Composer dependencies

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -52,17 +52,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Install Node dependencies
-        run: npm ci
-
-      - name: Build assets
-        run: npm run build
-
       - name: Generate APP_KEY
         run: echo "APP_KEY=base64:$(openssl rand -base64 32)" >> $GITHUB_ENV
 


### PR DESCRIPTION
Closes #47

The docker-compose-check job was running npm run build on the host runner before Composer dependencies were installed. The @laravel/vite-plugin-wayfinder plugin invokes php artisan wayfinder:generate during the Vite build, which requires vendor/autoload.php — causing a hard failure.

The fix removes the redundant Node setup + npm ci + npm run build steps from the docker-compose-check job. The Dockerfile's node-build stage already handles this internally, so the host-side build was unnecessary.