### PR TITLE
Enforce business rule in service and fix best-practice gaps

### DIFF
--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -30,7 +30,12 @@ Users without either permission are denied access to the notes area entirely (HT
 Spatie's permission system is used at the permission level (`can('view commission notes')`) rather than the role level (`hasRole('manager')`). This makes it easy to add new roles or reassign permissions later without touching the authorization code.
 
 ### Author-bypass on edit and delete
-The spec states "only the original author may edit a note unless the user has manage commission notes". The same principle is applied to deletion — an author can delete their own note, a manager can delete anyone's note. This is enforced in `CommissionNoteService` and the controller delegates fully to the service rather than duplicating the check.
+The spec states "only the original author may edit a note unless the user has manage commission notes". The same principle is applied to deletion — an author can delete their own note, a manager can delete anyone's note.
+
+Enforcement uses a deliberate dual-layer approach:
+
+1. **HTTP layer (policy)** — `CommissionNotePolicy::update()` and `CommissionNotePolicy::delete()` act as a coarse gate checked by the `UpdateCommissionNoteRequest::authorize()` method and by `$this->authorize()` in the controller's `destroy()` action. This rejects unauthorised HTTP requests early with a 403 before any service code runs.
+2. **Business-logic layer (service)** — `CommissionNoteService::update()` and `CommissionNoteService::delete()` each open with a `throw_unless(...)` guard that re-checks the same author-or-manage rule and throws `AuthorizationException` if it fails. This ensures the rule is enforced even if the service is called from outside the HTTP layer (e.g. console commands, queued jobs, or tests that bypass the controller).
 
 ### No separate API layer
 All data transfer goes through Inertia shared props and controller responses. There is no `/api` prefix or JSON-only endpoint. This keeps the surface area small for an internal tool and avoids duplicating authorization logic.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The seeder creates the following out-of-the-box accounts and data.
 |-------|----------|------|
 | `manager@example.com` | `password` | manager |
 | `viewer@example.com` | `password` | viewer |
-| `test@example.com` | `password` | *(none)* |
 
 ### Sample data
 

--- a/app/Http/Controllers/CommissionNoteController.php
+++ b/app/Http/Controllers/CommissionNoteController.php
@@ -45,8 +45,6 @@ class CommissionNoteController extends Controller
 
     public function update(UpdateCommissionNoteRequest $request, CommissionNote $note): RedirectResponse
     {
-        $this->authorize('update', $note);
-
         $this->service->update($note, $request->validated());
 
         return back()->with('success', 'Commission note updated.');

--- a/app/Http/Requests/StoreCommissionNoteRequest.php
+++ b/app/Http/Requests/StoreCommissionNoteRequest.php
@@ -42,7 +42,7 @@ class StoreCommissionNoteRequest extends FormRequest
                     ->where('company_id', $this->company_id)
                 ),
             ],
-            'amount' => ['required', 'numeric', 'min:0'],
+            'amount' => ['required', 'numeric', 'min:1'],
             'description' => ['nullable', 'string', 'max:1000'],
             'payment_date' => ['required', 'date'],
         ];

--- a/app/Http/Requests/UpdateCommissionNoteRequest.php
+++ b/app/Http/Requests/UpdateCommissionNoteRequest.php
@@ -18,7 +18,7 @@ class UpdateCommissionNoteRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'amount' => ['required', 'numeric', 'min:0'],
+            'amount' => ['required', 'numeric', 'min:1'],
             'description' => ['nullable', 'string', 'max:1000'],
             'payment_date' => ['required', 'date'],
         ];

--- a/app/Services/CommissionNoteService.php
+++ b/app/Services/CommissionNoteService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Events\CommissionNoteCreated;
 use App\Models\CommissionNote;
 use App\Models\CommissionNoteAudit;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Auth;
 
@@ -43,6 +44,12 @@ class CommissionNoteService
 
     public function update(CommissionNote $note, array $validated): CommissionNote
     {
+        throw_unless(
+            Auth::user()?->can('manage commission notes') || $note->created_by === Auth::id(),
+            AuthorizationException::class,
+            'You are not allowed to edit this note.',
+        );
+
         $oldValues = $this->auditableValues($note);
 
         $note->update([
@@ -60,6 +67,12 @@ class CommissionNoteService
 
     public function delete(CommissionNote $note): void
     {
+        throw_unless(
+            Auth::user()?->can('manage commission notes') || $note->created_by === Auth::id(),
+            AuthorizationException::class,
+            'You are not allowed to delete this note.',
+        );
+
         $this->recordAudit('deleted', $note->id, $this->auditableValues($note), null);
 
         $note->delete();

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -59,6 +59,7 @@ export type CommissionNote = {
     amount: string; // decimal cast serialises as string
     description: string | null;
     payment_date: string;
+    deleted_at?: string | null;
     employee?: Employee;
     author?: Pick<User, 'id' | 'name'>;
     audits?: CommissionNoteAudit[];

--- a/tests/Feature/CommissionNoteServiceTest.php
+++ b/tests/Feature/CommissionNoteServiceTest.php
@@ -3,6 +3,7 @@
 use App\Models\CommissionNote;
 use App\Models\User;
 use App\Services\CommissionNoteService;
+use Illuminate\Auth\Access\AuthorizationException;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -46,4 +47,18 @@ it('allows a manager to edit someone elses note', function () {
     ]);
 
     expect($updated->amount)->toBe('25000.00');
+});
+
+it('throws an authorization exception when a non-author without manage permission tries to update', function () {
+    $nonAuthor = User::factory()->create();
+    $nonAuthor->givePermissionTo('view commission notes');
+
+    $note = CommissionNote::factory()->create();
+
+    $this->actingAs($nonAuthor);
+
+    expect(fn () => (new CommissionNoteService)->update($note, [
+        'amount' => 99999,
+        'payment_date' => now()->toDateString(),
+    ]))->toThrow(AuthorizationException::class);
 });


### PR DESCRIPTION
Closes #55

## Summary

- **Business rule in service**: Added 	hrow_unless(...) guards to CommissionNoteService::update() and delete() — the author-or-manage rule now lives in the service layer as required by the Technical Assessment spec, not just in the policy.
- **New service test**: Added the missing restriction-case test — a non-author without manage commission notes permission now correctly throws AuthorizationException when calling the service directly.
- **Thin controller**: Removed the redundant \->authorize('update', \) from CommissionNoteController::update(); the same gate is already enforced by UpdateCommissionNoteRequest::authorize() and the service guard.
- **Amount validation**: Changed min:0 → min:1 in both StoreCommissionNoteRequest and UpdateCommissionNoteRequest — zero-dollar commission notes are not meaningful.
- **TypeScript type**: Added deleted_at?: string | null to the CommissionNote type to align with the model's SoftDeletes trait used by the restore workflow.
- **ASSESSMENT.md**: Updated the tradeoffs section to accurately describe the dual-layer enforcement pattern (policy as HTTP gate, service as business-logic enforcer).

## Test plan

- [ ] composer ci:check passes (ESLint + Prettier + vue-tsc + Pint + 39 Pest tests)