### PR TITLE
Fix ESLint import/order for type imports on Linux CI

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,7 +50,7 @@ export default defineConfigWithVueTs(
             'import/order': [
                 'error',
                 {
-                    groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+                    groups: ['type', 'builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
                     alphabetize: {
                         order: 'asc',
                         caseInsensitive: true,

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,9 +1,9 @@
 import '../css/app.css';
+import type { DefineComponent } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import ui from '@nuxt/ui/vue-plugin';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createPinia } from 'pinia';
-import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';

--- a/resources/js/components/NotificationBell.vue
+++ b/resources/js/components/NotificationBell.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue';
 import type { AppNotification } from '@/types/auth';
+import { onMounted, onUnmounted, ref } from 'vue';
 
 const unreadCount = ref(0);
 const notifications = ref<AppNotification[]>([]);

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
+import type { Auth, Branch, User } from '@/types/auth';
 import { Link, usePage } from '@inertiajs/vue3';
 import { computed, ref, shallowRef } from 'vue';
 import AppLogoLight from '@/components/AppLogoLight.vue';
 import CompanySwitcher from '@/components/CompanySwitcher.vue';
 import NotificationBell from '@/components/NotificationBell.vue';
-import type { Auth, Branch, User } from '@/types/auth';
 
 const page = usePage();
 const auth = computed(() => page.props.auth as Auth | undefined);

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -1,5 +1,5 @@
-import { clsx } from 'clsx';
 import type { ClassValue } from 'clsx';
+import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {

--- a/resources/js/pages/CommissionNotes/Index.vue
+++ b/resources/js/pages/CommissionNotes/Index.vue
@@ -1,4 +1,12 @@
 <script setup lang="ts">
+import type {
+    Branch,
+    CommissionNote,
+    CommissionNoteAudit,
+    Company,
+    Employee,
+    Paginated,
+} from '@/types/auth';
 import { Head, router, useForm, usePage } from '@inertiajs/vue3';
 import { useDebounceFn } from '@vueuse/core';
 import { computed, h, ref, resolveComponent, watch } from 'vue';
@@ -10,14 +18,6 @@ import {
 } from '@/actions/App/Http/Controllers/CommissionNoteController';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { useNoteStore } from '@/stores/noteStore';
-import type {
-    Branch,
-    CommissionNote,
-    CommissionNoteAudit,
-    Company,
-    Employee,
-    Paginated,
-} from '@/types/auth';
 
 defineOptions({ layout: AppLayout });
 

--- a/resources/js/pages/Dashboard/Index.vue
+++ b/resources/js/pages/Dashboard/Index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import type { BranchStat, EmployeeStat, RecentNote, User } from '@/types/auth';
 import { Head, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
-import type { BranchStat, EmployeeStat, RecentNote, User } from '@/types/auth';
 
 defineOptions({ layout: AppLayout });
 

--- a/resources/js/pages/Users/Index.vue
+++ b/resources/js/pages/Users/Index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import type { Branch } from '@/types/auth';
 import { Head, useForm } from '@inertiajs/vue3';
 import { computed, h, ref, resolveComponent } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
-import type { Branch } from '@/types/auth';
 
 defineOptions({ layout: AppLayout });
 

--- a/resources/js/stores/company.ts
+++ b/resources/js/stores/company.ts
@@ -1,7 +1,7 @@
+import type { Company } from '@/types/auth';
 import { usePage, router } from '@inertiajs/vue3';
 import { defineStore } from 'pinia';
 import { computed } from 'vue';
-import type { Company } from '@/types/auth';
 
 export const useCompanyStore = defineStore('company', () => {
     const page = usePage();

--- a/resources/js/stores/noteStore.ts
+++ b/resources/js/stores/noteStore.ts
@@ -1,6 +1,6 @@
+import type { CommissionNote } from '@/types/auth';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
-import type { CommissionNote } from '@/types/auth';
 
 export const useNoteStore = defineStore('notes', () => {
     const selectedNote = ref<CommissionNote | null>(null);


### PR DESCRIPTION
Closes #61

## What

Add \'type'\ as the first group in the \import/order\ ESLint rule, so all \import type\ statements are always sorted before regular imports — consistently on both Windows and Linux.

## Why

The \import/order\ rule in \slint-plugin-import@2.32.0\ resolves TypeScript type imports differently on Linux (case-sensitive filesystem, different resolver behaviour with \lwaysTryTypes\) than on Windows. Without an explicit group for type imports, the ordering was non-deterministic across platforms and caused PR CI to fail while local lint passed.

## Files changed

- \slint.config.js\ — add \'type'\ as first group in \import/order\
- 9 source files auto-fixed by ESLint to move \import type\ statements to the top of their import blocks