### PR TITLE
Pin @/actions imports to end of internal group via pathGroups

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,6 +51,13 @@ export default defineConfigWithVueTs(
                 'error',
                 {
                     groups: ['type', 'builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+                    pathGroups: [
+                        {
+                            pattern: '@/actions/**',
+                            group: 'internal',
+                            position: 'after',
+                        },
+                    ],
                     alphabetize: {
                         order: 'asc',
                         caseInsensitive: true,

--- a/resources/js/pages/CommissionNotes/Index.vue
+++ b/resources/js/pages/CommissionNotes/Index.vue
@@ -10,14 +10,14 @@ import type {
 import { Head, router, useForm, usePage } from '@inertiajs/vue3';
 import { useDebounceFn } from '@vueuse/core';
 import { computed, h, ref, resolveComponent, watch } from 'vue';
+import AppLayout from '@/layouts/AppLayout.vue';
+import { useNoteStore } from '@/stores/noteStore';
 import {
     destroy as destroyAction,
     index as indexAction,
     store as storeAction,
     update as updateAction,
 } from '@/actions/App/Http/Controllers/CommissionNoteController';
-import AppLayout from '@/layouts/AppLayout.vue';
-import { useNoteStore } from '@/stores/noteStore';
 
 defineOptions({ layout: AppLayout });
 


### PR DESCRIPTION
Closes #63

## What

Add a \pathGroups\ entry in \import/order\ that explicitly pins \@/actions/**\ to the \internal\ group with \position: 'after'\, and reorder \CommissionNotes/Index.vue\ to place the actions import last in the internal block.

## Why

On Linux CI, \slint-import-resolver-typescript\ cannot resolve \@/actions/**\ modules (the directory is in the ESLint ignore list, so the TypeScript program excludes it on case-sensitive filesystems). Without a resolved group, \import/order\ falls back to \index\ — which must appear after \internal\. Adding an explicit \pathGroups\ entry forces \@/actions/**\ to the end of \internal\ on both platforms, making the rule deterministic.