### PR TITLE
Fix types:check in CI by generating Wayfinder actions first

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -46,8 +46,23 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+
       - name: Install Node dependencies
         run: npm ci
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+
+      - name: Generate Wayfinder actions
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+          php artisan wayfinder:generate --no-interaction
 
       - name: Check code formatting
         run: npm run format:check


### PR DESCRIPTION
Closes #65

## Problem

The lint-frontend job was failing with:

`
TS2307: Cannot find module '@/actions/App/Http/Controllers/CommissionNoteController'
`

esources/js/actions and esources/js/wayfinder are git-ignored generated files produced by php artisan wayfinder:generate. The job only ran 
pm ci, so those directories never existed when ue-tsc ran.

## Fix

Added PHP 8.4 setup, composer install --no-scripts, and php artisan wayfinder:generate to the lint-frontend job so the generated action files are present before the TypeScript check runs.