### PR TITLE
Fix build-production CI job: install PHP deps before Vite build

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -129,14 +129,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
 
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+
       - name: Install Node dependencies
         run: npm ci
+
+      - name: Copy environment file
+        run: cp .env.example .env
+
+      - name: Generate application key
+        run: php artisan key:generate
 
       - name: Build production assets
         run: npm run build


### PR DESCRIPTION
Closes #67

## Problem
The `build-production` job ran `npm run build` without PHP or Composer being present. The `@laravel/vite-plugin-wayfinder` Vite plugin executes `php artisan wayfinder:generate --with-form` during the build, which requires `vendor/autoload.php`. Without it, the build fails immediately with a PHP fatal error.

## Fix
Added the following steps to `build-production` before `npm run build`:
- Setup PHP 8.4
- `composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts`
- Copy `.env.example` to `.env`
- `php artisan key:generate`