### PR TITLE
Restrict commission note edits to managers only

### DIFF
--- a/app/Policies/CommissionNotePolicy.php
+++ b/app/Policies/CommissionNotePolicy.php
@@ -19,14 +19,12 @@ class CommissionNotePolicy
 
     public function update(User $user, CommissionNote $note): bool
     {
-        return $user->can('manage commission notes')
-            || $note->created_by === $user->id;
+        return $user->can('manage commission notes');
     }
 
     public function delete(User $user, CommissionNote $note): bool
     {
-        return $user->can('manage commission notes')
-            || $note->created_by === $user->id;
+        return $user->can('manage commission notes');
     }
 
     public function restore(User $user, CommissionNote $note): bool

--- a/app/Services/CommissionNoteService.php
+++ b/app/Services/CommissionNoteService.php
@@ -45,7 +45,7 @@ class CommissionNoteService
     public function update(CommissionNote $note, array $validated): CommissionNote
     {
         throw_unless(
-            Auth::user()?->can('manage commission notes') || $note->created_by === Auth::id(),
+            Auth::user()?->can('manage commission notes'),
             AuthorizationException::class,
             'You are not allowed to edit this note.',
         );
@@ -68,7 +68,7 @@ class CommissionNoteService
     public function delete(CommissionNote $note): void
     {
         throw_unless(
-            Auth::user()?->can('manage commission notes') || $note->created_by === Auth::id(),
+            Auth::user()?->can('manage commission notes'),
             AuthorizationException::class,
             'You are not allowed to delete this note.',
         );

--- a/resources/js/pages/Auth/Login.vue
+++ b/resources/js/pages/Auth/Login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, useForm } from '@inertiajs/vue3';
+import { Head, useForm, Link  } from '@inertiajs/vue3';
 import AppLogo from '@/components/AppLogo.vue';
 import GuestLayout from '@/layouts/GuestLayout.vue';
 

--- a/resources/js/pages/CommissionNotes/Index.vue
+++ b/resources/js/pages/CommissionNotes/Index.vue
@@ -7,7 +7,7 @@ import type {
     Employee,
     Paginated,
 } from '@/types/auth';
-import { Head, router, useForm, usePage } from '@inertiajs/vue3';
+import { Head, router, useForm } from '@inertiajs/vue3';
 import { useDebounceFn } from '@vueuse/core';
 import { computed, h, ref, resolveComponent, watch } from 'vue';
 import AppLayout from '@/layouts/AppLayout.vue';
@@ -30,12 +30,7 @@ const props = defineProps<{
     filters: { search: string };
 }>();
 
-const page = usePage();
 const noteStore = useNoteStore();
-
-const currentUserId = computed(
-    () => (page.props.auth as any)?.user?.id as number,
-);
 
 const search = ref(props.filters.search ?? '');
 
@@ -248,7 +243,7 @@ const columns = [
     },
     {
         id: 'actions',
-        header: '',
+        header: 'Actions',
     },
 ];
 </script>
@@ -316,7 +311,7 @@ const columns = [
                 :columns="columns"
                 empty="No commission notes found."
             >
-                <template #actions-data="{ row }">
+                <template #actions-cell="{ row }">
                     <div class="flex items-center gap-2">
                         <UButton
                             label="History"
@@ -327,10 +322,7 @@ const columns = [
                             @click="openHistory(row.original)"
                         />
                         <UButton
-                            v-if="
-                                canManage ||
-                                row.original.created_by === currentUserId
-                            "
+                            v-if="canManage"
                             label="Edit"
                             color="neutral"
                             variant="ghost"
@@ -339,10 +331,7 @@ const columns = [
                             @click="noteStore.selectNote(row.original)"
                         />
                         <UButton
-                            v-if="
-                                canManage ||
-                                row.original.created_by === currentUserId
-                            "
+                            v-if="canManage"
                             label="Delete"
                             color="error"
                             variant="ghost"

--- a/tests/Feature/CommissionNoteServiceTest.php
+++ b/tests/Feature/CommissionNoteServiceTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
     Permission::create(['name' => 'manage commission notes']);
 });
 
-it('allows the original author to edit their own note without manage permission', function () {
+it('throws an authorization exception when a view-only author tries to update their note', function () {
     $author = User::factory()->create();
     $author->givePermissionTo('view commission notes');
 
@@ -22,13 +22,10 @@ it('allows the original author to edit their own note without manage permission'
 
     $this->actingAs($author);
 
-    $service = new CommissionNoteService;
-    $updated = $service->update($note, [
+    expect(fn () => (new CommissionNoteService)->update($note, [
         'amount' => 15000,
         'payment_date' => now()->toDateString(),
-    ]);
-
-    expect($updated->amount)->toBe('15000.00');
+    ]))->toThrow(AuthorizationException::class);
 });
 
 it('allows a manager to edit someone elses note', function () {

--- a/tests/Feature/CommissionNoteTest.php
+++ b/tests/Feature/CommissionNoteTest.php
@@ -99,7 +99,7 @@ it('forbids updating a note the view-only user did not author', function () {
     ])->assertForbidden();
 });
 
-it('allows a view-only user to update a note they authored', function () {
+it('forbids a view-only user from updating a note they authored', function () {
     $viewer = User::factory()->create();
     $viewer->givePermissionTo('view commission notes');
 
@@ -108,11 +108,11 @@ it('allows a view-only user to update a note they authored', function () {
     $this->actingAs($viewer)->patch(route('notes.update', $note), [
         'amount' => 12000,
         'payment_date' => now()->toDateString(),
-    ])->assertRedirect();
+    ])->assertForbidden();
 
     $this->assertDatabaseHas('commission_notes', [
         'id' => $note->id,
-        'amount' => 12000,
+        'amount' => $note->amount,
     ]);
 });
 
@@ -129,16 +129,16 @@ it('forbids deleting a note the view-only user did not author', function () {
         ->assertForbidden();
 });
 
-it('allows the original author to delete their own note', function () {
+it('forbids a view-only user from deleting a note they authored', function () {
     $author = User::factory()->create();
     $author->givePermissionTo('view commission notes');
 
     $note = CommissionNote::factory()->create(['created_by' => $author->id]);
 
     $this->actingAs($author)->delete(route('notes.destroy', $note))
-        ->assertRedirect();
+        ->assertForbidden();
 
-    $this->assertSoftDeleted('commission_notes', ['id' => $note->id]);
+    $this->assertDatabaseHas('commission_notes', ['id' => $note->id]);
 });
 
 it('does not return notes from other branches', function () {


### PR DESCRIPTION
Closes #71

Changes:
- CommissionNotePolicy: update and delete now require manage commission notes only; the created_by bypass is removed
- CommissionNoteService: the redundant throw_unless guards in update() and delete() likewise drop the author bypass
- CommissionNotes/Index.vue: Edit and Delete buttons use v-if=canManage only; removed now-unused currentUserId computed and usePage import
- Tests: updated two HTTP tests and one service test to assert the new forbidden behaviour for view-only authors

Audit trail: No changes needed. create/update/delete/restore events are already recorded via CommissionNoteAudit and surfaced in the History modal with field-level diffs.