### PR TITLE
Fix author-edit rule: allow authors to update/delete own notes

### DIFF
--- a/app/Policies/CommissionNotePolicy.php
+++ b/app/Policies/CommissionNotePolicy.php
@@ -19,12 +19,14 @@ class CommissionNotePolicy
 
     public function update(User $user, CommissionNote $note): bool
     {
-        return $user->can('manage commission notes');
+        return $user->id === $note->created_by
+            || $user->can('manage commission notes');
     }
 
     public function delete(User $user, CommissionNote $note): bool
     {
-        return $user->can('manage commission notes');
+        return $user->id === $note->created_by
+            || $user->can('manage commission notes');
     }
 
     public function restore(User $user, CommissionNote $note): bool

--- a/app/Services/CommissionNoteService.php
+++ b/app/Services/CommissionNoteService.php
@@ -45,7 +45,7 @@ class CommissionNoteService
     public function update(CommissionNote $note, array $validated): CommissionNote
     {
         throw_unless(
-            Auth::user()?->can('manage commission notes'),
+            Auth::id() === $note->created_by || Auth::user()?->can('manage commission notes'),
             AuthorizationException::class,
             'You are not allowed to edit this note.',
         );
@@ -68,7 +68,7 @@ class CommissionNoteService
     public function delete(CommissionNote $note): void
     {
         throw_unless(
-            Auth::user()?->can('manage commission notes'),
+            Auth::id() === $note->created_by || Auth::user()?->can('manage commission notes'),
             AuthorizationException::class,
             'You are not allowed to delete this note.',
         );

--- a/resources/js/pages/Auth/Login.vue
+++ b/resources/js/pages/Auth/Login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Head, useForm, Link  } from '@inertiajs/vue3';
+import { Head, useForm, Link } from '@inertiajs/vue3';
 import AppLogo from '@/components/AppLogo.vue';
 import GuestLayout from '@/layouts/GuestLayout.vue';
 

--- a/tests/Feature/CommissionNoteServiceTest.php
+++ b/tests/Feature/CommissionNoteServiceTest.php
@@ -14,13 +14,29 @@ beforeEach(function () {
     Permission::create(['name' => 'manage commission notes']);
 });
 
-it('throws an authorization exception when a view-only author tries to update their note', function () {
+it('allows the original author to update their own note', function () {
     $author = User::factory()->create();
     $author->givePermissionTo('view commission notes');
 
-    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
+    $note = CommissionNote::factory()->create(['created_by' => $author->id, 'amount' => 10000]);
 
     $this->actingAs($author);
+
+    $updated = (new CommissionNoteService)->update($note, [
+        'amount' => 15000,
+        'payment_date' => now()->toDateString(),
+    ]);
+
+    expect($updated->amount)->toBe('15000.00');
+});
+
+it('throws when a non-author without manage permission tries to update', function () {
+    $nonAuthor = User::factory()->create();
+    $nonAuthor->givePermissionTo('view commission notes');
+
+    $note = CommissionNote::factory()->create();
+
+    $this->actingAs($nonAuthor);
 
     expect(fn () => (new CommissionNoteService)->update($note, [
         'amount' => 15000,
@@ -44,18 +60,4 @@ it('allows a manager to edit someone elses note', function () {
     ]);
 
     expect($updated->amount)->toBe('25000.00');
-});
-
-it('throws an authorization exception when a non-author without manage permission tries to update', function () {
-    $nonAuthor = User::factory()->create();
-    $nonAuthor->givePermissionTo('view commission notes');
-
-    $note = CommissionNote::factory()->create();
-
-    $this->actingAs($nonAuthor);
-
-    expect(fn () => (new CommissionNoteService)->update($note, [
-        'amount' => 99999,
-        'payment_date' => now()->toDateString(),
-    ]))->toThrow(AuthorizationException::class);
 });

--- a/tests/Feature/CommissionNoteTest.php
+++ b/tests/Feature/CommissionNoteTest.php
@@ -99,20 +99,20 @@ it('forbids updating a note the view-only user did not author', function () {
     ])->assertForbidden();
 });
 
-it('forbids a view-only user from updating a note they authored', function () {
-    $viewer = User::factory()->create();
-    $viewer->givePermissionTo('view commission notes');
+it('allows the author to update their own note', function () {
+    $author = User::factory()->create();
+    $author->givePermissionTo('view commission notes');
 
-    $note = CommissionNote::factory()->create(['created_by' => $viewer->id]);
+    $note = CommissionNote::factory()->create(['created_by' => $author->id]);
 
-    $this->actingAs($viewer)->patch(route('notes.update', $note), [
+    $this->actingAs($author)->patch(route('notes.update', $note), [
         'amount' => 12000,
         'payment_date' => now()->toDateString(),
-    ])->assertForbidden();
+    ])->assertRedirect();
 
     $this->assertDatabaseHas('commission_notes', [
         'id' => $note->id,
-        'amount' => $note->amount,
+        'amount' => 12000,
     ]);
 });
 
@@ -129,16 +129,16 @@ it('forbids deleting a note the view-only user did not author', function () {
         ->assertForbidden();
 });
 
-it('forbids a view-only user from deleting a note they authored', function () {
+it('allows the author to delete their own note', function () {
     $author = User::factory()->create();
     $author->givePermissionTo('view commission notes');
 
     $note = CommissionNote::factory()->create(['created_by' => $author->id]);
 
     $this->actingAs($author)->delete(route('notes.destroy', $note))
-        ->assertForbidden();
+        ->assertRedirect();
 
-    $this->assertDatabaseHas('commission_notes', ['id' => $note->id]);
+    $this->assertSoftDeleted('commission_notes', ['id' => $note->id]);
 });
 
 it('does not return notes from other branches', function () {


### PR DESCRIPTION
Closes #73. Policy and service were enforcing manage-only for update/delete, blocking the original author from editing their own note. Both layers now enforce author-OR-manage. Tests updated to verify the correct behaviour. Pre-existing Prettier issue in Login.vue also fixed.